### PR TITLE
fix: service restart

### DIFF
--- a/bin/bridge/assets/reth-mainnet.service
+++ b/bin/bridge/assets/reth-mainnet.service
@@ -7,6 +7,7 @@ StartLimitIntervalSec=0
 Type=simple
 Restart=always
 RestartSec=1
+StartLimitAction=reboot
 User=ubuntu
 Group=ubuntu
 UMask=0002


### PR DESCRIPTION
Avoids the shutdown of the service on multiple restart burst in a short interval. With a restart of 1 second, 5 consecutive restarts in a short interval (< 10 seconds) will trigger the default [`StartLimitBurst` option](https://www.freedesktop.org/software/systemd/man/latest/systemd.unit.html#StartLimitIntervalSec=interval), permanently shutting down the service.  