### PR TITLE
Fix #66: Auto-create database file if it doesn't exist

### DIFF
--- a/bin/rollup/src/network.rs
+++ b/bin/rollup/src/network.rs
@@ -122,7 +122,7 @@ where
         } else {
             // append the path using strings as using `join(...)` overwrites "sqlite://"
             // if the path is absolute.
-            let path = ctx.config().datadir().db().join("scroll.db");
+            let path = ctx.config().datadir().db().join("scroll.db?mode=rwc");
             "sqlite://".to_string() + &*path.to_string_lossy()
         };
         let db = Database::new(&database_path).await?;

--- a/crates/database/db/src/db.rs
+++ b/crates/database/db/src/db.rs
@@ -2,6 +2,7 @@ use super::{transaction::DatabaseTransaction, DatabaseConnectionProvider};
 use crate::error::DatabaseError;
 
 use sea_orm::{Database as SeaOrmDatabase, DatabaseConnection, TransactionTrait};
+use std::path::Path;
 
 /// The [`Database`] struct is responsible for interacting with the database.
 ///
@@ -19,7 +20,39 @@ pub struct Database {
 impl Database {
     /// Creates a new [`Database`] instance associated with the provided database URL.
     pub async fn new(database_url: &str) -> Result<Self, DatabaseError> {
+        // Ensure the parent directory exists for file-based databases
+        if database_url.starts_with("sqlite://") && !database_url.contains(":memory:") {
+            // Extract the file path portion from the URL
+            let file_path = &database_url["sqlite://".len()..];
+            if !file_path.is_empty() {
+                // Create the parent directory if it doesn't exist
+                if let Some(parent_dir) = Path::new(file_path).parent() {
+                    if !parent_dir.exists() {
+                        tracing::info!(target: "scroll::db", "Creating database directory: {:?}", parent_dir);
+                        std::fs::create_dir_all(parent_dir).map_err(|e| {
+                            DatabaseError::DatabaseError(sea_orm::DbErr::Custom(format!(
+                                "Failed to create database directory: {}",
+                                e
+                            )))
+                        })?;
+                    }
+                }
+            }
+        }
+
+        // Connect to the database
         let connection = SeaOrmDatabase::connect(database_url).await?;
+        
+        // Run migrations to ensure the schema is up to date
+        tracing::info!(target: "scroll::db", "Running database migrations");
+        migration::Migrator::up(&connection, None).await.map_err(|e| {
+            DatabaseError::DatabaseError(sea_orm::DbErr::Custom(format!(
+                "Failed to apply database migrations: {}",
+                e
+            )))
+        })?;
+        tracing::info!(target: "scroll::db", "Database migrations complete");
+
         Ok(Self { connection })
     }
 


### PR DESCRIPTION
# Auto-create database file if it doesn't exist

## Description
This PR fixes [issue #66](https://github.com/scroll-tech/rollup-node/issues/66) where the node crashes if the database file hasn't been created before launch.

## Changes
- Added directory creation logic to ensure the database parent directory exists
- Added automatic migration execution when connecting to the database
- Added proper error handling and logging for the database initialization process

## Impact
With these changes, the node will automatically create the database file and directory structure if they don't exist, then apply the required migrations to set up the database schema. This improves the user experience by eliminating the need for manual database file creation.

## Testing
- Tested with non-existing database file and directory
- Verified migrations are properly applied to new database
- Ensured existing database files continue to work as before

Fixes #66