### PR TITLE
feat: extend node config

### DIFF
--- a/bin/rollup/src/constants.rs
+++ b/bin/rollup/src/constants.rs
@@ -1,6 +1,3 @@
-/// The block number at which to start the L1 watcher.
-pub const WATCHER_START_BLOCK_NUMBER: u64 = 18318215;
-
 /// The size of the blob cache for the provider.
 pub const PROVIDER_BLOB_CACHE_SIZE: usize = 100;
 

--- a/bin/rollup/src/lib.rs
+++ b/bin/rollup/src/lib.rs
@@ -6,7 +6,7 @@ pub use args::{
 };
 
 mod constants;
-pub use constants::{PROVIDER_INITIAL_BACKOFF, PROVIDER_MAX_RETRIES, WATCHER_START_BLOCK_NUMBER};
+pub use constants::{PROVIDER_INITIAL_BACKOFF, PROVIDER_MAX_RETRIES};
 
 mod import;
 pub use import::BridgeBlockImport;

--- a/bin/rollup/src/network.rs
+++ b/bin/rollup/src/network.rs
@@ -1,7 +1,4 @@
-use crate::{
-    constants::PROVIDER_BLOB_CACHE_SIZE, L1ProviderArgs, ScrollRollupNodeArgs,
-    WATCHER_START_BLOCK_NUMBER,
-};
+use crate::{constants::PROVIDER_BLOB_CACHE_SIZE, L1ProviderArgs, ScrollRollupNodeArgs};
 use std::{collections::HashSet, sync::Arc, time::Duration};
 
 use alloy_provider::ProviderBuilder;
@@ -180,7 +177,7 @@ where
             let mut poa = PoAConsensus::new(HashSet::new());
             if let Some(ref provider) = provider {
                 let signer =
-                    provider.authorized_signer(node_config.system_contract_address()).await?;
+                    provider.authorized_signer(node_config.system_contract_address).await?;
                 poa.update_config(&ConsensusUpdate::AuthorizedSigner(signer));
             }
             Box::new(poa)
@@ -188,7 +185,7 @@ where
 
         let l1_notification_rx = if let Some(provider) = provider {
             // Spawn the L1Watcher
-            Some(L1Watcher::spawn(provider, WATCHER_START_BLOCK_NUMBER, node_config).await)
+            Some(L1Watcher::spawn(provider, node_config).await)
         } else {
             None
         };

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -18,7 +18,10 @@ pub use bounded_vec::BoundedVec;
 
 mod node;
 pub use node::{
-    config::{NodeConfig, MAINNET_SYSTEM_CONTRAT_ADDRESS, SEPOLIA_SYSTEM_CONTRAT_ADDRESS},
+    config::{
+        NodeConfig, MAINNET_L1_START_BLOCK_NUMBER, MAINNET_SYSTEM_CONTRAT_ADDRESS,
+        SEPOLIA_L1_START_BLOCK_NUMBER, SEPOLIA_SYSTEM_CONTRAT_ADDRESS,
+    },
     consensus::ConsensusUpdate,
 };
 

--- a/crates/primitives/src/node/config.rs
+++ b/crates/primitives/src/node/config.rs
@@ -9,22 +9,36 @@ pub const SEPOLIA_SYSTEM_CONTRAT_ADDRESS: Address =
 pub const MAINNET_SYSTEM_CONTRAT_ADDRESS: Address =
     address!("8432728A257646449245558B8b7Dbe51A16c7a4D");
 
+/// The L1 start block for Mainnet.
+pub const MAINNET_L1_START_BLOCK_NUMBER: u64 = 18318215;
+
+/// The L1 start block for Sepolia.
+pub const SEPOLIA_L1_START_BLOCK_NUMBER: u64 = 4041343;
+
 /// A shared configuration for the node.
 #[derive(Debug, Clone)]
 pub struct NodeConfig {
     /// The address of the system contract used in consensus.
-    system_contract_address: Address,
+    pub system_contract_address: Address,
+    /// The start block for the L1 sync.
+    pub start_l1_block: u64,
 }
 
 impl NodeConfig {
     /// Returns the node configuration for mainnet.
     pub const fn mainnet() -> Self {
-        Self { system_contract_address: MAINNET_SYSTEM_CONTRAT_ADDRESS }
+        Self {
+            system_contract_address: MAINNET_SYSTEM_CONTRAT_ADDRESS,
+            start_l1_block: MAINNET_L1_START_BLOCK_NUMBER,
+        }
     }
 
     /// Returns the node configuration for sepolia.
     pub const fn sepolia() -> Self {
-        Self { system_contract_address: SEPOLIA_SYSTEM_CONTRAT_ADDRESS }
+        Self {
+            system_contract_address: SEPOLIA_SYSTEM_CONTRAT_ADDRESS,
+            start_l1_block: SEPOLIA_L1_START_BLOCK_NUMBER,
+        }
     }
 
     /// Returns the node configuration from a [`NamedChain`].
@@ -34,10 +48,5 @@ impl NodeConfig {
             NamedChain::ScrollSepolia => Self::sepolia(),
             _ => panic!("expected Scroll Mainnet or Sepolia"),
         }
-    }
-
-    /// Returns the current system contract address.
-    pub const fn system_contract_address(&self) -> Address {
-        self.system_contract_address
     }
 }

--- a/crates/watcher/src/lib.rs
+++ b/crates/watcher/src/lib.rs
@@ -118,7 +118,6 @@ where
     /// returning [`L1Notification`] in the returned channel.
     pub async fn spawn(
         execution_provider: EP,
-        start_block: BlockNumber,
         config: Arc<NodeConfig>,
     ) -> mpsc::Receiver<Arc<L1Notification>> {
         let (tx, rx) = mpsc::channel(LOGS_QUERY_BLOCK_RANGE as usize);
@@ -146,7 +145,7 @@ where
         let watcher = Self {
             execution_provider,
             unfinalized_blocks: BoundedVec::new(HEADER_CAPACITY),
-            current_block_number: start_block - 1,
+            current_block_number: config.start_l1_block - 1,
             l1_state,
             sender: tx,
             config,
@@ -449,7 +448,7 @@ where
         if latest_block.header.number != self.l1_state.head {
             let signer = self
                 .execution_provider
-                .authorized_signer(self.config.system_contract_address())
+                .authorized_signer(self.config.system_contract_address)
                 .await?;
             self.notify(L1Notification::Consensus(ConsensusUpdate::AuthorizedSigner(signer))).await;
         }

--- a/crates/watcher/tests/reorg.rs
+++ b/crates/watcher/tests/reorg.rs
@@ -58,7 +58,10 @@ async fn test_reorg_detection() -> eyre::Result<()> {
         .collect::<Vec<_>>();
     finalized_blocks.sort_unstable_by(|a, b| a.header.number.cmp(&b.header.number));
 
-    let start = latest_blocks.first().unwrap().header.number;
+    let config = NodeConfig {
+        start_l1_block: latest_blocks.first().unwrap().header.number,
+        system_contract_address: Default::default(),
+    };
     let mock_provider = MockProvider::new(
         blocks.clone().into_iter(),
         std::iter::empty(),
@@ -67,8 +70,7 @@ async fn test_reorg_detection() -> eyre::Result<()> {
     );
 
     // spawn the watcher and verify received notifications are consistent.
-    let mut l1_watcher =
-        L1Watcher::spawn(mock_provider, start, Arc::new(NodeConfig::mainnet())).await;
+    let mut l1_watcher = L1Watcher::spawn(mock_provider, Arc::new(config)).await;
 
     // skip the first two events
     l1_watcher.recv().await.unwrap();
@@ -142,7 +144,10 @@ async fn test_gap() -> eyre::Result<()> {
         .collect::<Vec<_>>();
     finalized_blocks.sort_unstable_by(|a, b| a.header.number.cmp(&b.header.number));
 
-    let start = latest_blocks.first().unwrap().header.number;
+    let config = NodeConfig {
+        start_l1_block: latest_blocks.first().unwrap().header.number,
+        system_contract_address: Default::default(),
+    };
     let mock_provider = MockProvider::new(
         blocks.clone().into_iter(),
         std::iter::empty(),
@@ -151,8 +156,7 @@ async fn test_gap() -> eyre::Result<()> {
     );
 
     // spawn the watcher and verify received notifications are consistent.
-    let mut l1_watcher =
-        L1Watcher::spawn(mock_provider, start, Arc::new(NodeConfig::mainnet())).await;
+    let mut l1_watcher = L1Watcher::spawn(mock_provider, Arc::new(config)).await;
 
     // skip the first two events
     l1_watcher.recv().await.unwrap();


### PR DESCRIPTION
Adds the initial L1 block for the L1 watcher to the node config.