### PR TITLE
feat: add a `finalized` predicate to `L1MessageProvider`

### DIFF
--- a/crates/indexer/src/lib.rs
+++ b/crates/indexer/src/lib.rs
@@ -59,6 +59,11 @@ impl<ChainSpec: ScrollHardforks + EthChainSpec + Send + Sync + 'static> Indexer<
         }
     }
 
+    /// Returns the current L1 finalized block number.
+    pub fn get_l1_finalized_block_number(&self) -> u64 {
+        self.l1_finalized_block_number.load(Ordering::Relaxed)
+    }
+
     /// Handles an L2 block.
     pub fn handle_block(
         &mut self,

--- a/crates/manager/src/manager/mod.rs
+++ b/crates/manager/src/manager/mod.rs
@@ -243,8 +243,14 @@ where
                     pipeline.handle_batch_commit(batch_info);
                 }
             }
-            IndexerEvent::BatchFinalizationIndexed(_, Some(finalized_block)) |
-            IndexerEvent::FinalizedIndexed(_, Some(finalized_block)) => {
+            IndexerEvent::BatchFinalizationIndexed(_, Some(finalized_block)) => {
+                // update the fcs on new finalized block.
+                self.engine.set_finalized_block_info(finalized_block);
+            }
+            IndexerEvent::FinalizedIndexed(l1_block_number, Some(finalized_block)) => {
+                if let Some(sequencer) = self.sequencer.as_mut() {
+                    sequencer.set_l1_finalized_block_number(l1_block_number);
+                }
                 // update the fcs on new finalized block.
                 self.engine.set_finalized_block_info(finalized_block);
             }

--- a/crates/node/src/add_ons/rollup.rs
+++ b/crates/node/src/add_ons/rollup.rs
@@ -22,7 +22,7 @@ use rollup_node_primitives::NodeConfig;
 use rollup_node_providers::{
     beacon_provider, DatabaseL1MessageProvider, OnlineL1Provider, SystemContractProvider,
 };
-use rollup_node_sequencer::Sequencer;
+use rollup_node_sequencer::{L1MessageInclusionMode, Sequencer};
 use rollup_node_signer::Signer;
 use rollup_node_watcher::{L1Notification, L1Watcher};
 use scroll_alloy_hardforks::ScrollHardforks;
@@ -192,12 +192,25 @@ impl RollupManagerAddOn {
         // Construct the Sequencer.
         let (sequencer, block_time) = if self.config.sequencer_args.sequencer_enabled {
             let args = &self.config.sequencer_args;
+
+            // Parse L1 inclusion mode from CLI args
+            let l1_inclusion_mode = match args.l1_inclusion_mode.as_str() {
+                "finalized" => L1MessageInclusionMode::Finalized,
+                "block-depth" => L1MessageInclusionMode::BlockDepth(args.l1_block_depth),
+                _ => {
+                    return Err(eyre::eyre!(
+                        "Invalid L1 inclusion mode: {}",
+                        args.l1_inclusion_mode
+                    ));
+                }
+            };
+
             let sequencer = Sequencer::new(
                 Arc::new(l1_messages_provider),
                 args.fee_recipient,
                 args.max_l1_messages_per_block,
                 0,
-                0,
+                l1_inclusion_mode,
             );
             (Some(sequencer), (args.block_time != 0).then_some(args.block_time))
         } else {

--- a/crates/node/src/args.rs
+++ b/crates/node/src/args.rs
@@ -110,4 +110,15 @@ pub struct SequencerArgs {
     /// The fee recipient for the sequencer.
     #[arg(long = "sequencer.fee-recipient", id = "sequencer_fee_recipient", value_name = "SEQUENCER_FEE_RECIPIENT", default_value_t = SCROLL_FEE_VAULT_ADDRESS)]
     pub fee_recipient: Address,
+    /// L1 message inclusion mode: either "block-depth" or "finalized"
+    #[arg(
+        long = "sequencer.l1-inclusion-mode",
+        id = "sequencer_l1_inclusion_mode",
+        value_name = "SEQUENCER_L1_INCLUSION_MODE",
+        default_value = "block-depth"
+    )]
+    pub l1_inclusion_mode: String,
+    /// L1 block depth for block depth mode (number of confirmations to wait)
+    #[arg(long = "sequencer.l1-block-depth", id = "sequencer_l1_block_depth", value_name = "SEQUENCER_L1_BLOCK_DEPTH", default_value_t = constants::DEFAULT_L1_BLOCK_DEPTH)]
+    pub l1_block_depth: u64,
 }

--- a/crates/node/src/constants.rs
+++ b/crates/node/src/constants.rs
@@ -21,3 +21,6 @@ pub(crate) const DEFAULT_MAX_L1_MESSAGES_PER_BLOCK: u64 = 4;
 
 /// The gap in blocks between the P2P and EN which triggers sync.
 pub(crate) const BLOCK_GAP_TRIGGER: u64 = 500_000;
+
+/// Default L1 block depth for sequencer (number of confirmations to wait)
+pub(crate) const DEFAULT_L1_BLOCK_DEPTH: u64 = 12;

--- a/crates/node/src/test_utils.rs
+++ b/crates/node/src/test_utils.rs
@@ -158,6 +158,8 @@ pub fn default_sequencer_test_scroll_rollup_node_config() -> ScrollRollupNodeCon
             payload_building_duration: 0,
             max_l1_messages_per_block: 0,
             fee_recipient: Default::default(),
+            l1_inclusion_mode: "block-depth".to_string(),
+            l1_block_depth: 0,
         },
         beacon_provider_args: BeaconProviderArgs::default(),
     }

--- a/crates/node/tests/e2e.rs
+++ b/crates/node/tests/e2e.rs
@@ -38,6 +38,8 @@ async fn can_bridge_l1_messages() -> eyre::Result<()> {
             sequencer_enabled: true,
             block_time: 0,
             max_l1_messages_per_block: 4,
+            l1_inclusion_mode: "block-depth".to_string(),
+            l1_block_depth: 0,
             ..SequencerArgs::default()
         },
         beacon_provider_args: BeaconProviderArgs::default(),
@@ -100,6 +102,8 @@ async fn can_sequence_and_gossip_blocks() {
             sequencer_enabled: true,
             block_time: 0,
             max_l1_messages_per_block: 4,
+            l1_inclusion_mode: "block-depth".to_string(),
+            l1_block_depth: 0,
             ..SequencerArgs::default()
         },
         beacon_provider_args: BeaconProviderArgs::default(),

--- a/crates/sequencer/tests/e2e.rs
+++ b/crates/sequencer/tests/e2e.rs
@@ -56,7 +56,13 @@ async fn can_build_blocks() {
     let provider = Arc::new(DatabaseL1MessageProvider::new(database.clone(), 0));
 
     // create a sequencer
-    let mut sequencer = Sequencer::new(provider, Default::default(), 4, 1, 0);
+    let mut sequencer = Sequencer::new(
+        provider,
+        Default::default(),
+        4,
+        1,
+        rollup_node_sequencer::L1MessageInclusionMode::BlockDepth(0),
+    );
 
     // add a transaction to the pool
     let mut wallet_lock = wallet.lock().await;
@@ -175,7 +181,13 @@ async fn can_build_blocks_with_delayed_l1_messages() {
     let provider = Arc::new(DatabaseL1MessageProvider::new(database.clone(), 0));
 
     // create a sequencer
-    let mut sequencer = Sequencer::new(provider, Default::default(), 4, 0, L1_MESSAGE_DELAY);
+    let mut sequencer = Sequencer::new(
+        provider,
+        Default::default(),
+        4,
+        0,
+        rollup_node_sequencer::L1MessageInclusionMode::BlockDepth(L1_MESSAGE_DELAY),
+    );
 
     // now lets add an L1 message to the database (this transaction should not be included until the
     // l1 block number is 3)
@@ -252,4 +264,136 @@ async fn can_build_blocks_with_delayed_l1_messages() {
     assert_eq!(block.body.transactions.len(), 1);
     assert_eq!(block.header.number(), 2);
     assert_eq!(block.header.parent_hash, block_1_hash);
+}
+
+#[tokio::test]
+async fn can_build_blocks_with_finalized_l1_messages() {
+    reth_tracing::init_test_tracing();
+
+    let chain_spec = SCROLL_DEV.clone();
+    const BLOCK_BUILDING_DURATION: Duration = tokio::time::Duration::from_millis(0);
+    const BLOCK_GAP_TRIGGER: u64 = 100;
+
+    // setup a test node
+    let (mut nodes, _tasks, wallet) =
+        setup_engine(default_test_scroll_rollup_node_config(), 1, chain_spec, false).await.unwrap();
+    let node = nodes.pop().unwrap();
+    let wallet = Arc::new(Mutex::new(wallet));
+
+    // create a forkchoice state
+    let genesis_hash = node.inner.chain_spec().genesis_hash();
+    let fcs = ForkchoiceState::new(
+        BlockInfo { hash: genesis_hash, number: 0 },
+        Default::default(),
+        Default::default(),
+    );
+
+    // create the engine driver connected to the node
+    let auth_client = node.inner.engine_http_client();
+    let engine_client = ScrollAuthApiEngineClient::new(auth_client);
+    let mut engine_driver = EngineDriver::new(
+        Arc::new(engine_client),
+        (*SCROLL_DEV).clone(),
+        None::<ScrollRootProvider>,
+        fcs,
+        false,
+        BLOCK_GAP_TRIGGER,
+        BLOCK_BUILDING_DURATION,
+    );
+
+    // create a test database
+    let database = Arc::new(setup_test_db().await);
+    let provider = Arc::new(DatabaseL1MessageProvider::new(database.clone(), 0));
+
+    // create a sequencer with Finalized mode
+    let mut sequencer = Sequencer::new(
+        provider,
+        Default::default(),
+        4,
+        5, // current L1 block number
+        rollup_node_sequencer::L1MessageInclusionMode::Finalized,
+    );
+
+    // set L1 finalized block number to 2
+    sequencer.set_l1_finalized_block_number(2);
+
+    // add L1 messages to database
+    let wallet_lock = wallet.lock().await;
+
+    // this message should be included (before finalized block)
+    let finalized_l1_message = L1MessageEnvelope {
+        l1_block_number: 2, // <= 2 (finalized block)
+        l2_block_number: None,
+        queue_hash: None,
+        transaction: TxL1Message {
+            queue_index: 0,
+            gas_limit: 21000,
+            to: Address::random(),
+            value: U256::from(1),
+            sender: wallet_lock.inner.address(),
+            input: vec![].into(),
+        },
+    };
+
+    // this message should not be included (after finalized block)
+    let unfinalized_l1_message = L1MessageEnvelope {
+        l1_block_number: 3, // > 2 (finalized block)
+        l2_block_number: None,
+        queue_hash: None,
+        transaction: TxL1Message {
+            queue_index: 1,
+            gas_limit: 21000,
+            to: Address::random(),
+            value: U256::from(2),
+            sender: wallet_lock.inner.address(),
+            input: vec![].into(),
+        },
+    };
+    drop(wallet_lock);
+
+    let finalized_message_hash = finalized_l1_message.transaction.tx_hash();
+    let unfinalized_message_hash = unfinalized_l1_message.transaction.tx_hash();
+
+    database.insert_l1_message(finalized_l1_message).await.unwrap();
+    database.insert_l1_message(unfinalized_l1_message).await.unwrap();
+
+    // build payload, should only include finalized message
+    sequencer.build_payload_attributes();
+    let payload_attributes = sequencer.next().await.unwrap();
+    engine_driver.handle_build_new_payload(payload_attributes);
+
+    let block = if let Some(EngineDriverEvent::NewPayload(block)) = engine_driver.next().await {
+        block
+    } else {
+        panic!("expected a new payload event");
+    };
+
+    // verify only finalized L1 message is included
+    assert_eq!(block.body.transactions.len(), 1);
+    assert_eq!(block.body.transactions.first().unwrap().tx_hash(), &finalized_message_hash);
+
+    // ensure unfinalized message is not included
+    assert!(!block.body.transactions.iter().any(|tx| tx.tx_hash() == &unfinalized_message_hash));
+
+    // update finalized block number to 3, now both messages should be available
+    sequencer.set_l1_finalized_block_number(3);
+
+    // sleep 2 seconds (ethereum header timestamp has granularity of seconds and proceeding header
+    // must have a greater timestamp than the last)
+    tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+
+    // build new payload
+    sequencer.build_payload_attributes();
+    let payload_attributes = sequencer.next().await.unwrap();
+    engine_driver.handle_build_new_payload(payload_attributes);
+
+    let block = if let Some(EngineDriverEvent::NewPayload(block)) = engine_driver.next().await {
+        block
+    } else {
+        panic!("expected a new payload event");
+    };
+
+    // now should include the previously unfinalized message
+    assert_eq!(block.body.transactions.len(), 1);
+    assert_eq!(block.body.transactions.first().unwrap().tx_hash(), &unfinalized_message_hash);
 }


### PR DESCRIPTION
# Overview
This PR introduces a `finalized` predicate for `L1MessageProvider` to allow filtering L1 messages based on finalization status instead of block depth. It also adds CLI flags to allow users to choose between `block depth` mode and `finalized` mode for L1 message inclusion.

closes [#143](https://github.com/scroll-tech/rollup-node/issues/143).