### PR TITLE
feat: add private key file configuration for sequencer signing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9617,6 +9617,7 @@ dependencies = [
  "scroll-network",
  "scroll-wire",
  "serde_json",
+ "tempfile",
  "tokio",
  "tracing",
 ]

--- a/README.md
+++ b/README.md
@@ -123,8 +123,10 @@ To run a sequencer node you should build the binary in release mode using the in
 Then, you can run the sequencer node with the following command:
 
 ```sh
-./target/release/rollup-node node --chain dev -d --scroll-sequencer-enabled --http --http.api admin,debug,eth,net,trace,txpool,web3,rpc,reth,ots,flashbots,miner,mev
+./target/release/rollup-node node --chain dev --sequencer.enabled --signer.key-file /path/to/your/private.key --http --http.api admin,debug,eth,net,trace,txpool,web3,rpc,reth,ots,flashbots,miner,mev
 ```
+
+**Note**: When running a sequencer, a signer key file is required unless the `--test` flag is specified. Use the `--signer.key-file` option to specify the path to your private key file. Keep your private key file secure and never commit it to version control.
 
 This will start a dev node in sequencer mode with all rpc apis enabled. You can adjust the `--http.api` flag to include or exclude specific APIs as needed.
 
@@ -147,6 +149,8 @@ A list of sequencer specific configuration options can be seen below:
           The max L1 messages per block for the sequencer [default: 4]
       --fee-recipient <FEE_RECIPIENT>
           The fee recipient for the sequencer [default: 0x5300000000000000000000000000000000000005]
+      --signer.key-file <FILE_PATH>
+          Path to the signer's private key file (required when sequencer is enabled)
 ```
 
 ## Contributing

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -93,6 +93,7 @@ reth-tracing.workspace = true
 rollup-node = { workspace = true, features = ["test-utils"] }
 scroll-alloy-rpc-types-engine.workspace = true
 serde_json = { version = "1.0.94", default-features = false, features = ["alloc"] }
+tempfile = "3.0"
 
 [features]
 test-utils = [

--- a/crates/node/src/args.rs
+++ b/crates/node/src/args.rs
@@ -28,6 +28,22 @@ pub struct ScrollRollupNodeConfig {
     /// The network arguments
     #[command(flatten)]
     pub network_args: NetworkArgs,
+    /// The signer arguments
+    #[command(flatten)]
+    pub signer_args: SignerArgs,
+}
+
+impl ScrollRollupNodeConfig {
+    /// Validate that signer key file is provided when sequencer is enabled
+    pub fn validate(&self) -> Result<(), String> {
+        if !self.test &&
+            self.sequencer_args.sequencer_enabled &&
+            self.signer_args.key_file.is_none()
+        {
+            return Err("Signer key file is required when sequencer is enabled".to_string());
+        }
+        Ok(())
+    }
 }
 
 /// The database arguments.
@@ -121,4 +137,90 @@ pub struct SequencerArgs {
         help = "L1 message inclusion mode. Use 'finalized' for finalized messages only, or 'depth:{number}' for block depth confirmation (e.g. 'depth:10')"
     )]
     pub l1_message_inclusion_mode: L1MessageInclusionMode,
+}
+
+/// The arguments for the signer.
+#[derive(Debug, Default, Clone, clap::Args)]
+pub struct SignerArgs {
+    /// Path to the file containing the signer's private key
+    #[arg(
+        long = "signer.key-file",
+        value_name = "FILE_PATH",
+        help = "Path to the signer's private key file (required when sequencer is enabled)"
+    )]
+    pub key_file: Option<PathBuf>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn test_validate_sequencer_enabled_without_key_file_fails() {
+        let config = ScrollRollupNodeConfig {
+            test: false,
+            sequencer_args: SequencerArgs { sequencer_enabled: true, ..Default::default() },
+            signer_args: SignerArgs { key_file: None },
+            database_args: DatabaseArgs::default(),
+            engine_driver_args: EngineDriverArgs::default(),
+            l1_provider_args: L1ProviderArgs::default(),
+            beacon_provider_args: BeaconProviderArgs::default(),
+            network_args: NetworkArgs::default(),
+        };
+
+        let result = config.validate();
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .contains("Signer key file is required when sequencer is enabled"));
+    }
+
+    #[test]
+    fn test_validate_sequencer_enabled_with_key_file_succeeds() {
+        let config = ScrollRollupNodeConfig {
+            test: false,
+            sequencer_args: SequencerArgs { sequencer_enabled: true, ..Default::default() },
+            signer_args: SignerArgs { key_file: Some(PathBuf::from("/path/to/key")) },
+            database_args: DatabaseArgs::default(),
+            engine_driver_args: EngineDriverArgs::default(),
+            l1_provider_args: L1ProviderArgs::default(),
+            beacon_provider_args: BeaconProviderArgs::default(),
+            network_args: NetworkArgs::default(),
+        };
+
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn test_validate_test_mode_without_key_file_succeeds() {
+        let config = ScrollRollupNodeConfig {
+            test: true,
+            sequencer_args: SequencerArgs { sequencer_enabled: true, ..Default::default() },
+            signer_args: SignerArgs { key_file: None },
+            database_args: DatabaseArgs::default(),
+            engine_driver_args: EngineDriverArgs::default(),
+            l1_provider_args: L1ProviderArgs::default(),
+            beacon_provider_args: BeaconProviderArgs::default(),
+            network_args: NetworkArgs::default(),
+        };
+
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn test_validate_sequencer_disabled_without_key_file_succeeds() {
+        let config = ScrollRollupNodeConfig {
+            test: false,
+            sequencer_args: SequencerArgs { sequencer_enabled: false, ..Default::default() },
+            signer_args: SignerArgs { key_file: None },
+            database_args: DatabaseArgs::default(),
+            engine_driver_args: EngineDriverArgs::default(),
+            l1_provider_args: L1ProviderArgs::default(),
+            beacon_provider_args: BeaconProviderArgs::default(),
+            network_args: NetworkArgs::default(),
+        };
+
+        assert!(config.validate().is_ok());
+    }
 }

--- a/crates/node/src/test_utils.rs
+++ b/crates/node/src/test_utils.rs
@@ -139,6 +139,7 @@ pub fn default_test_scroll_rollup_node_config() -> ScrollRollupNodeConfig {
         engine_driver_args: EngineDriverArgs { en_sync_trigger: 100 },
         sequencer_args: SequencerArgs::default(),
         beacon_provider_args: BeaconProviderArgs::default(),
+        signer_args: Default::default(),
     }
 }
 
@@ -162,5 +163,6 @@ pub fn default_sequencer_test_scroll_rollup_node_config() -> ScrollRollupNodeCon
             l1_message_inclusion_mode: L1MessageInclusionMode::BlockDepth(0),
         },
         beacon_provider_args: BeaconProviderArgs::default(),
+        signer_args: Default::default(),
     }
 }

--- a/crates/node/tests/e2e.rs
+++ b/crates/node/tests/e2e.rs
@@ -43,6 +43,7 @@ async fn can_bridge_l1_messages() -> eyre::Result<()> {
             ..SequencerArgs::default()
         },
         beacon_provider_args: BeaconProviderArgs::default(),
+        signer_args: Default::default(),
     };
     let (mut nodes, _tasks, _wallet) = setup_engine(node_args, 1, chain_spec, false).await?;
     let node = nodes.pop().unwrap();
@@ -106,6 +107,7 @@ async fn can_sequence_and_gossip_blocks() {
             ..SequencerArgs::default()
         },
         beacon_provider_args: BeaconProviderArgs::default(),
+        signer_args: Default::default(),
     };
 
     let (nodes, _tasks, wallet) =

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -16,7 +16,7 @@ services:
           --log.stdout.format log-fmt -vvv --l1.url http://l1reth-rpc.sepolia.scroll.tech:8545 --beacon.url http://l1reth-cl.sepolia.scroll.tech:5052 --network.scroll-wire --network.bridge 
           --trusted-peers "enode://29cee709c400533ae038a875b9ca975c8abef9eade956dcf3585e940acd5c0ae916968f514bd37d1278775aad1b7db30f7032a70202a87fd7365bd8de3c9f5fc@44.242.39.33:30303,enode://ceb1636bac5cbb262e5ad5b2cd22014bdb35ffe7f58b3506970d337a63099481814a338dbcd15f2d28757151e3ecd40ba38b41350b793cd0d910ff0436654f8c@35.85.84.250:30303,enode://dd1ac5433c5c2b04ca3166f4cb726f8ff6d2da83dbc16d9b68b1ea83b7079b371eb16ef41c00441b6e85e32e33087f3b7753ea9e8b1e3f26d3e4df9208625e7f@54.148.111.168:30303"
       elif [ "$${ENV:-}" = "mainnet" ]; then
-        exec rollup-node node --chain scroll --datadir=/l2reth --metrics=0.0.0.0:6060 --disable-discovery \
+        exec rollup-node node --chain scroll-mainnet --datadir=/l2reth --metrics=0.0.0.0:6060 --disable-discovery \
           --http --http.addr=0.0.0.0 --http.port=8545 --http.corsdomain "*" --http.api admin,debug,eth,net,trace,txpool,web3,rpc,reth,ots,flashbots,miner,mev 
           --ws --ws.addr 0.0.0.0 --ws.port 8546 --ws.api admin,debug,eth,net,trace,txpool,web3,rpc,reth,ots,flashbots,miner,mev \
           --log.stdout.format log-fmt -vvv --l1.url http://l1geth-rpc.mainnet.scroll.tech:8545/l1 --beacon.url http://l1reth-cl.mainnet.scroll.tech:5052 --network.scroll-wire --network.bridge \


### PR DESCRIPTION
# Overview
This PR introduces signing key configuration for the sequencer by adding CLI support for specifying a private key file. It adds a new `SignerArgs` struct with the `--signer.key-file` parameter and implements conditional validation to ensure the key file is required when the sequencer is enabled (and test mode is disabled).

closes [#146](https://github.com/scroll-tech/rollup-node/issues/146).