### PR TITLE
feat: bump scroll-revm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9290,7 +9290,7 @@ dependencies = [
 [[package]]
 name = "revm-scroll"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/scroll-revm#0c222b9298806809edd9a6f6ab5d415abcab588c"
+source = "git+https://github.com/scroll-tech/scroll-revm#54e4e90105d95f14c0d055f0e37bd689b6f22306"
 dependencies = [
  "auto_impl",
  "enumn",


### PR DESCRIPTION
Bumps scroll revm to include the [change](https://github.com/scroll-tech/scroll-revm/pull/43) related to max l1 data cost.