### PR TITLE
fix: pin nextest version

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -27,7 +27,9 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
-      - uses: taiki-e/install-action@nextest
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: nextest@0.9.98
       - name: Run unit tests
         run: cargo nextest run --all-features --workspace --locked -E '!kind(test)'
 
@@ -45,6 +47,8 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
-      - uses: taiki-e/install-action@nextest
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: nextest@0.9.98
       - name: Run integration tests
         run: cargo nextest run --all-features --workspace --locked --no-tests=pass -E 'kind(test)'


### PR DESCRIPTION
# Overview
The latest version of `nextest` introduces a bug when using it in CI. This issue pins the nextest version. I have created an issue to track this in the future #176.