### PR TITLE
fix: fix block data hint migration vector allocation

### DIFF
--- a/crates/database/migration/src/m20250408_150338_load_header_metadata.rs
+++ b/crates/database/migration/src/m20250408_150338_load_header_metadata.rs
@@ -125,7 +125,7 @@ async fn download(url: &str) -> eyre::Result<Vec<u8>> {
     pb.set_position(0);
 
     // init variables.
-    let mut buf = Vec::with_capacity(total_size as usize);
+    let mut buf = Vec::with_capacity(iterations as usize);
     let mut index = 0;
     let mut cursor = 0;
     let mut tasks = FuturesUnordered::new();


### PR DESCRIPTION
This bug was resulting in a huge allocation. Instead of the file size,e we should allocate the number of iterations. This should be confirmed by @greged93.