### PR TITLE
fix: sync test

### DIFF
--- a/crates/engine/src/driver.rs
+++ b/crates/engine/src/driver.rs
@@ -2,7 +2,7 @@ use super::{future::EngineFuture, ForkchoiceState};
 use crate::{
     future::{BuildNewPayloadFuture, EngineDriverFutureResult},
     metrics::EngineDriverMetrics,
-    EngineDriverEvent,
+    EngineDriverError, EngineDriverEvent,
 };
 
 use alloy_provider::Provider;
@@ -237,7 +237,10 @@ where
                         return Some(EngineDriverEvent::NewPayload(block))
                     }
                     Err(err) => {
-                        tracing::error!(target: "scroll::engine", ?err, "failed to build new payload")
+                        tracing::error!(target: "scroll::engine", ?err, "failed to build new payload");
+                        if let EngineDriverError::MissingPayloadId(attributes) = err {
+                            self.l1_payload_attributes.push_front(attributes);
+                        }
                     }
                 }
             }

--- a/crates/engine/src/error.rs
+++ b/crates/engine/src/error.rs
@@ -1,4 +1,5 @@
 use alloy_rpc_types_engine::PayloadError;
+use rollup_node_primitives::ScrollPayloadAttributesWithBatchInfo;
 use scroll_alloy_provider::ScrollEngineApiError;
 
 /// The error type for the engine API.
@@ -13,10 +14,10 @@ pub enum EngineDriverError {
     /// The execution payload provider is unavailable.
     #[error("Execution payload provider is unavailable")]
     ExecutionPayloadProviderUnavailable,
-    /// The execution payload id is missing.
-    #[error("missing payload id")]
-    MissingExecutionPayloadId,
     /// The forkchoice update failed.
     #[error("Forkchoice update failed: {0}")]
     ForkchoiceUpdateFailed(ScrollEngineApiError),
+    /// The payload id field is missing in the forkchoice update response.
+    #[error("Forkchoice update response missing payload id")]
+    MissingPayloadId(ScrollPayloadAttributesWithBatchInfo),
 }

--- a/crates/engine/src/future/mod.rs
+++ b/crates/engine/src/future/mod.rs
@@ -232,23 +232,23 @@ where
 #[instrument(skip_all, level = "trace",
         fields(
              fcs = ?fcs,
-             payload_attributes = ?payload_attributes
+             payload_attributes = ?payload_attributes_with_batch_info
         )
     )]
 async fn handle_payload_attributes<EC, P>(
     client: Arc<EC>,
     provider: P,
     fcs: ForkchoiceState,
-    payload_attributes: ScrollPayloadAttributesWithBatchInfo,
+    payload_attributes_with_batch_info: ScrollPayloadAttributesWithBatchInfo,
 ) -> Result<ConsolidationOutcome, EngineDriverError>
 where
     EC: ScrollEngineApi + Unpin + Send + Sync + 'static,
     P: Provider<Scroll> + Unpin + Send + Sync + 'static,
 {
-    tracing::trace!(target: "scroll::engine::future", ?fcs, ?payload_attributes, "handling payload attributes");
+    tracing::trace!(target: "scroll::engine::future", ?fcs, ?payload_attributes_with_batch_info, "handling payload attributes");
 
     let ScrollPayloadAttributesWithBatchInfo { mut payload_attributes, batch_info } =
-        payload_attributes;
+        payload_attributes_with_batch_info.clone();
 
     let maybe_execution_payload = provider
         .get_block((fcs.safe_block_info().number + 1).into())
@@ -288,7 +288,9 @@ where
         // retrieve the execution payload
         let execution_payload = get_payload(
             client.clone(),
-            fc_updated.payload_id.expect("payload attributes has been set"),
+            fc_updated
+                .payload_id
+                .ok_or(EngineDriverError::MissingPayloadId(payload_attributes_with_batch_info))?,
         )
         .await?;
         // issue the execution payload to the EL


### PR DESCRIPTION
# Overview
This PR fixes the errors we have been experiencing with the sync test, which is run as part of CI. I speculate that when the `engineAPI` is overloaded due to a high number of payload-building requests, it eventually stops returning a payload ID until it has handled the current load. We address this issue by catching the case in which a payload ID is not returned and then retrying until a payload ID is returned. 