### PR TITLE
feat: log ScrollChainConfig on node startup

### DIFF
--- a/crates/node/src/main.rs
+++ b/crates/node/src/main.rs
@@ -23,6 +23,9 @@ fn main() {
             let handle = builder
                 .node(ScrollRollupNode::new(args))
                 .launch_with_fn(|builder| {
+                    // Log ScrollChainConfig during node launch as requested in the issue
+                    let chain = &builder.config().chain;
+                    info!(target: "reth::cli", "ScrollChainConfig: {:?}", chain);
                     // We must use `always_process_payload_attributes_on_canonical_head` in order to
                     // be able to build payloads with the forkchoice state API
                     // on top of heads part of the canonical state. Not


### PR DESCRIPTION
## Description
Adds logging of the ScrollChainConfig during node launch as requested in issue #222.

## Changes
- Added logging inside the `launch_with_fn` closure in `main.rs`
- Logs the complete chain specification using debug formatting
- Provides operators visibility into chain configuration at startup

## Testing
- Code compiles successfully
- Clippy passes with no warnings
- Formatting is correct

Closes #222