### PR TITLE
feat(consensus): Add consensus check for block sequencing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10336,6 +10336,7 @@ dependencies = [
  "reth-node-builder",
  "reth-node-core",
  "reth-node-types",
+ "reth-primitives-traits",
  "reth-provider",
  "reth-revm",
  "reth-rpc-api",
@@ -10524,6 +10525,7 @@ dependencies = [
 name = "rollup-node-signer"
 version = "0.0.1"
 dependencies = [
+ "alloy-primitives",
  "alloy-signer",
  "alloy-signer-local",
  "futures",

--- a/Makefile
+++ b/Makefile
@@ -64,11 +64,12 @@ lint: fmt lint-toml clippy udeps codespell zepter
 
 .PHONY: test
 test:
-	cargo test \
+	cargo nextest run \
 	--workspace \
 	--locked \
 	--all-features \
-	--no-fail-fast
+	--no-fail-fast \
+	-E 'not test(docker)'
 
 # Used to update the mainnet-sample.sql data. Provide the path to the sqlite database that should be read from
 # using `DB_PATH`.

--- a/crates/manager/src/consensus.rs
+++ b/crates/manager/src/consensus.rs
@@ -15,6 +15,8 @@ pub trait Consensus: Send + Debug {
         block: &ScrollBlock,
         signature: &Signature,
     ) -> Result<(), ConsensusError>;
+    /// Returns a boolean indicating whether the sequencer should sequence a block.
+    fn should_sequence_block(&self, sequencer: &Address) -> bool;
 }
 
 /// A no-op consensus instance.
@@ -31,6 +33,10 @@ impl Consensus for NoopConsensus {
         _signature: &Signature,
     ) -> Result<(), ConsensusError> {
         Ok(())
+    }
+
+    fn should_sequence_block(&self, _sequencer: &Address) -> bool {
+        true
     }
 }
 
@@ -70,6 +76,10 @@ impl Consensus for SystemContractConsensus {
             }))
         }
         Ok(())
+    }
+
+    fn should_sequence_block(&self, sequencer: &Address) -> bool {
+        sequencer == &self.authorized_signer
     }
 }
 

--- a/crates/manager/src/manager/mod.rs
+++ b/crates/manager/src/manager/mod.rs
@@ -317,6 +317,8 @@ where
                     let _ = signer.sign_block(payload.clone()).inspect_err(|err| error!(target: "scroll::node::manager", ?err, "Failed to send new payload to signer"));
                 }
 
+                println!("new payload sequenced by {:?}", self.signer.as_ref().map(|s| s.address));
+
                 if let Some(event_sender) = self.event_sender.as_ref() {
                     event_sender.notify(RollupManagerEvent::BlockSequenced(payload.clone()));
                 }
@@ -510,21 +512,22 @@ where
         proceed_if!(
             en_synced,
             // Check if we need to trigger the build of a new payload.
-            match (
-                this.block_building_trigger.as_mut().map(|x| x.poll_tick(cx)),
-                this.engine.is_payload_building_in_progress(),
+            if let (Some(Poll::Ready(_)), Some(sequencer)) = (
+                this.block_building_trigger.as_mut().map(|se| se.poll_tick(cx)),
+                this.sequencer.as_mut()
             ) {
-                (Some(Poll::Ready(_)), false) => {
-                    if let Some(sequencer) = this.sequencer.as_mut() {
-                        sequencer.build_payload_attributes();
-                    }
-                }
-                (Some(Poll::Ready(_)), true) => {
-                    // If the sequencer is already building a payload, we don't need to trigger it
-                    // again.
+                if !this.consensus.should_sequence_block(
+                    this.signer
+                        .as_ref()
+                        .map(|s| &s.address)
+                        .expect("signer must be set if sequencer is present"),
+                ) {
+                    trace!(target: "scroll::node::manager", "Signer is not authorized to sequence block for this slot");
+                } else if this.engine.is_payload_building_in_progress() {
                     warn!(target: "scroll::node::manager", "Payload building is already in progress skipping slot");
+                } else {
+                    sequencer.build_payload_attributes();
                 }
-                _ => {}
             }
         );
 

--- a/crates/manager/src/manager/mod.rs
+++ b/crates/manager/src/manager/mod.rs
@@ -317,8 +317,6 @@ where
                     let _ = signer.sign_block(payload.clone()).inspect_err(|err| error!(target: "scroll::node::manager", ?err, "Failed to send new payload to signer"));
                 }
 
-                println!("new payload sequenced by {:?}", self.signer.as_ref().map(|s| s.address));
-
                 if let Some(event_sender) = self.event_sender.as_ref() {
                     event_sender.notify(RollupManagerEvent::BlockSequenced(payload.clone()));
                 }

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -95,6 +95,7 @@ futures.workspace = true
 reth-e2e-test-utils.workspace = true
 reth-node-core.workspace = true
 reth-provider.workspace = true
+reth-primitives-traits.workspace = true
 reth-rpc-server-types.workspace = true
 reth-scroll-node = { workspace = true, features = ["test-utils"] }
 reth-tasks.workspace = true
@@ -140,4 +141,6 @@ test-utils = [
     "scroll-alloy-rpc-types-engine",
     "alloy-rpc-types-engine",
     "scroll-derivation-pipeline",
+    "reth-primitives-traits/test-utils",
+    "reth-primitives-traits/test-utils",
 ]

--- a/crates/node/src/args.rs
+++ b/crates/node/src/args.rs
@@ -45,6 +45,9 @@ pub struct ScrollRollupNodeConfig {
     /// Whether the rollup node should be run in test mode.
     #[arg(long)]
     pub test: bool,
+    /// Consensus args
+    #[command(flatten)]
+    pub consensus_args: ConsensusArgs,
     /// Database args
     #[command(flatten)]
     pub database_args: DatabaseArgs,
@@ -74,14 +77,32 @@ pub struct ScrollRollupNodeConfig {
 impl ScrollRollupNodeConfig {
     /// Validate that either signer key file or AWS KMS key ID is provided when sequencer is enabled
     pub fn validate(&self) -> Result<(), String> {
-        if !self.test && self.sequencer_args.sequencer_enabled {
-            if self.signer_args.key_file.is_none() && self.signer_args.aws_kms_key_id.is_none() {
-                return Err("Either signer key file or AWS KMS key ID is required when sequencer is enabled".to_string());
+        if self.sequencer_args.sequencer_enabled &
+            !matches!(self.consensus_args.algorithm, ConsensusAlgorithm::Noop)
+        {
+            if self.signer_args.key_file.is_none() &&
+                self.signer_args.aws_kms_key_id.is_none() &&
+                self.signer_args.private_key.is_none()
+            {
+                return Err("Either signer key file, AWS KMS key ID or private key is required when sequencer is enabled".to_string());
             }
-            if self.signer_args.key_file.is_some() && self.signer_args.aws_kms_key_id.is_some() {
-                return Err("Cannot specify both signer key file and AWS KMS key ID".to_string());
+
+            if (self.signer_args.key_file.is_some() as u8 +
+                self.signer_args.aws_kms_key_id.is_some() as u8 +
+                self.signer_args.private_key.is_some() as u8) >
+                1
+            {
+                return Err("Cannot specify more than one signer key source".to_string());
             }
         }
+
+        if self.consensus_args.algorithm == ConsensusAlgorithm::SystemContract &&
+            self.consensus_args.authorized_signer.is_none() &&
+            self.l1_provider_args.url.is_none()
+        {
+            return Err("System contract consensus requires either an authorized signer or a L1 provider URL".to_string());
+        }
+
         Ok(())
     }
 }
@@ -202,13 +223,23 @@ impl ScrollRollupNodeConfig {
         );
 
         // Create the consensus.
-        let consensus: Box<dyn Consensus> = if let Some(ref provider) = l1_provider {
-            let signer = provider
-                .authorized_signer(node_config.address_book.system_contract_address)
-                .await?;
-            Box::new(SystemContractConsensus::new(signer))
-        } else {
-            Box::new(NoopConsensus::default())
+        let consensus: Box<dyn Consensus> = match self.consensus_args.algorithm {
+            ConsensusAlgorithm::Noop => Box::new(NoopConsensus::default()),
+            ConsensusAlgorithm::SystemContract => {
+                let authorized_signer = if let Some(address) = self.consensus_args.authorized_signer
+                {
+                    address
+                } else if let Some(provider) = l1_provider.as_ref() {
+                    provider
+                        .authorized_signer(node_config.address_book.system_contract_address)
+                        .await?
+                } else {
+                    return Err(eyre::eyre!(
+                        "System contract consensus requires either an authorized signer or a L1 provider URL"
+                    ));
+                };
+                Box::new(SystemContractConsensus::new(authorized_signer))
+            }
         };
 
         let (l1_notification_tx, l1_notification_rx): (Option<Sender<Arc<L1Notification>>>, _) =
@@ -295,6 +326,45 @@ pub struct DatabaseArgs {
     /// Database path
     #[arg(long)]
     pub path: Option<PathBuf>,
+}
+
+/// The database arguments.
+#[derive(Debug, Default, Clone, clap::Args)]
+pub struct ConsensusArgs {
+    /// The type of consensus to use.
+    #[arg(
+        long = "consensus.algorithm",
+        value_name = "CONSENSUS_ALGORITHM",
+        default_value = "system-contract"
+    )]
+    pub algorithm: ConsensusAlgorithm,
+
+    /// The optional authorized signer for system contract consensus.
+    #[arg(long = "consensus.authorized-signer", value_name = "ADDRESS")]
+    pub authorized_signer: Option<Address>,
+}
+
+impl ConsensusArgs {
+    /// Create a new [`ConsensusArgs`] with the no-op consensus algorithm.
+    pub const fn noop() -> Self {
+        Self { algorithm: ConsensusAlgorithm::Noop, authorized_signer: None }
+    }
+}
+
+/// The consensus algorithm to use.
+#[derive(Debug, clap::ValueEnum, Clone, PartialEq, Eq)]
+pub enum ConsensusAlgorithm {
+    /// System contract consensus with an optional authorized signer. If the authorized signer is
+    /// not provided the system will use the L1 provider to query the authorized signer from L1.
+    SystemContract,
+    /// No-op consensus that does not validate blocks.
+    Noop,
+}
+
+impl Default for ConsensusAlgorithm {
+    fn default() -> Self {
+        Self::SystemContract
+    }
 }
 
 /// The engine driver args.
@@ -424,6 +494,9 @@ pub struct SignerArgs {
         help = "AWS KMS Key ID for signing transactions. Mutually exclusive with --signer.key-file"
     )]
     pub aws_kms_key_id: Option<String>,
+
+    /// The private key signer, if any.
+    pub private_key: Option<PrivateKeySigner>,
 }
 
 impl SignerArgs {
@@ -455,7 +528,7 @@ impl SignerArgs {
                 .map_err(|e| eyre::eyre!("Failed to create signer from key file: {}", e))?
                 .with_chain_id(Some(chain_id));
 
-            tracing::info!(
+            tracing::info!(target: "scroll::node::args",
                 "Created private key signer with address: {} for chain ID: {}",
                 private_key_signer.address(),
                 chain_id
@@ -474,12 +547,17 @@ impl SignerArgs {
                 .map_err(|e| eyre::eyre!("Failed to initialize AWS KMS signer: {}", e))?;
 
             tracing::info!(
+                target: "scroll::node::args",
                 "Created AWS KMS signer with address: {} for chain ID: {}",
                 aws_signer.address(),
                 chain_id
             );
 
             Ok(Some(Box::new(aws_signer)))
+        } else if let Some(private_key) = &self.private_key {
+            tracing::info!(target: "scroll::node::args", "Created private key signer with address: {} for chain ID: {}", private_key.address(), chain_id);
+            let signer = private_key.clone().with_chain_id(Some(chain_id));
+            Ok(Some(Box::new(signer)))
         } else {
             Ok(None)
         }
@@ -505,19 +583,23 @@ mod tests {
         let config = ScrollRollupNodeConfig {
             test: false,
             sequencer_args: SequencerArgs { sequencer_enabled: true, ..Default::default() },
-            signer_args: SignerArgs { key_file: None, aws_kms_key_id: None },
+            signer_args: SignerArgs { key_file: None, aws_kms_key_id: None, private_key: None },
             database_args: DatabaseArgs::default(),
             engine_driver_args: EngineDriverArgs::default(),
             l1_provider_args: L1ProviderArgs::default(),
             beacon_provider_args: BeaconProviderArgs::default(),
             network_args: NetworkArgs::default(),
             gas_price_oracle_args: GasPriceOracleArgs::default(),
+            consensus_args: ConsensusArgs {
+                algorithm: ConsensusAlgorithm::SystemContract,
+                authorized_signer: None,
+            },
         };
 
         let result = config.validate();
         assert!(result.is_err());
         assert!(result.unwrap_err().contains(
-            "Either signer key file or AWS KMS key ID is required when sequencer is enabled"
+            "Either signer key file, AWS KMS key ID or private key is required when sequencer is enabled"
         ));
     }
 
@@ -529,6 +611,7 @@ mod tests {
             signer_args: SignerArgs {
                 key_file: Some(PathBuf::from("/path/to/key")),
                 aws_kms_key_id: Some("key-id".to_string()),
+                private_key: None,
             },
             database_args: DatabaseArgs::default(),
             engine_driver_args: EngineDriverArgs::default(),
@@ -536,13 +619,15 @@ mod tests {
             beacon_provider_args: BeaconProviderArgs::default(),
             network_args: NetworkArgs::default(),
             gas_price_oracle_args: GasPriceOracleArgs::default(),
+            consensus_args: ConsensusArgs {
+                algorithm: ConsensusAlgorithm::SystemContract,
+                authorized_signer: None,
+            },
         };
 
         let result = config.validate();
         assert!(result.is_err());
-        assert!(result
-            .unwrap_err()
-            .contains("Cannot specify both signer key file and AWS KMS key ID"));
+        assert!(result.unwrap_err().contains("Cannot specify more than one signer key source"));
     }
 
     #[test]
@@ -553,6 +638,7 @@ mod tests {
             signer_args: SignerArgs {
                 key_file: Some(PathBuf::from("/path/to/key")),
                 aws_kms_key_id: None,
+                private_key: None,
             },
             database_args: DatabaseArgs::default(),
             engine_driver_args: EngineDriverArgs::default(),
@@ -560,6 +646,7 @@ mod tests {
             beacon_provider_args: BeaconProviderArgs::default(),
             network_args: NetworkArgs::default(),
             gas_price_oracle_args: GasPriceOracleArgs::default(),
+            consensus_args: ConsensusArgs::noop(),
         };
 
         assert!(config.validate().is_ok());
@@ -570,30 +657,18 @@ mod tests {
         let config = ScrollRollupNodeConfig {
             test: false,
             sequencer_args: SequencerArgs { sequencer_enabled: true, ..Default::default() },
-            signer_args: SignerArgs { key_file: None, aws_kms_key_id: Some("key-id".to_string()) },
+            signer_args: SignerArgs {
+                key_file: None,
+                aws_kms_key_id: Some("key-id".to_string()),
+                private_key: None,
+            },
             database_args: DatabaseArgs::default(),
             engine_driver_args: EngineDriverArgs::default(),
             l1_provider_args: L1ProviderArgs::default(),
             beacon_provider_args: BeaconProviderArgs::default(),
             network_args: NetworkArgs::default(),
             gas_price_oracle_args: GasPriceOracleArgs::default(),
-        };
-
-        assert!(config.validate().is_ok());
-    }
-
-    #[test]
-    fn test_validate_test_mode_without_any_signer_succeeds() {
-        let config = ScrollRollupNodeConfig {
-            test: true,
-            sequencer_args: SequencerArgs { sequencer_enabled: true, ..Default::default() },
-            signer_args: SignerArgs { key_file: None, aws_kms_key_id: None },
-            database_args: DatabaseArgs::default(),
-            engine_driver_args: EngineDriverArgs::default(),
-            l1_provider_args: L1ProviderArgs::default(),
-            beacon_provider_args: BeaconProviderArgs::default(),
-            network_args: NetworkArgs::default(),
-            gas_price_oracle_args: GasPriceOracleArgs::default(),
+            consensus_args: ConsensusArgs::noop(),
         };
 
         assert!(config.validate().is_ok());
@@ -604,13 +679,14 @@ mod tests {
         let config = ScrollRollupNodeConfig {
             test: false,
             sequencer_args: SequencerArgs { sequencer_enabled: false, ..Default::default() },
-            signer_args: SignerArgs { key_file: None, aws_kms_key_id: None },
+            signer_args: SignerArgs { key_file: None, aws_kms_key_id: None, private_key: None },
             database_args: DatabaseArgs::default(),
             engine_driver_args: EngineDriverArgs::default(),
             l1_provider_args: L1ProviderArgs::default(),
             beacon_provider_args: BeaconProviderArgs::default(),
             network_args: NetworkArgs::default(),
             gas_price_oracle_args: GasPriceOracleArgs::default(),
+            consensus_args: ConsensusArgs::noop(),
         };
 
         assert!(config.validate().is_ok());

--- a/crates/node/src/test_utils.rs
+++ b/crates/node/src/test_utils.rs
@@ -1,6 +1,6 @@
 //! This crate contains utilities for running end-to-end tests for the scroll reth node.
 
-use crate::GasPriceOracleArgs;
+use crate::{ConsensusArgs, GasPriceOracleArgs};
 
 use super::{
     BeaconProviderArgs, DatabaseArgs, EngineDriverArgs, L1ProviderArgs, ScrollRollupNode,
@@ -152,6 +152,7 @@ pub fn default_test_scroll_rollup_node_config() -> ScrollRollupNodeConfig {
         },
         signer_args: Default::default(),
         gas_price_oracle_args: GasPriceOracleArgs::default(),
+        consensus_args: ConsensusArgs::noop(),
     }
 }
 
@@ -177,5 +178,6 @@ pub fn default_sequencer_test_scroll_rollup_node_config() -> ScrollRollupNodeCon
         },
         signer_args: Default::default(),
         gas_price_oracle_args: GasPriceOracleArgs::default(),
+        consensus_args: ConsensusArgs::noop(),
     }
 }

--- a/crates/node/tests/sync.rs
+++ b/crates/node/tests/sync.rs
@@ -12,8 +12,8 @@ use rollup_node::{
         default_sequencer_test_scroll_rollup_node_config, default_test_scroll_rollup_node_config,
         setup_engine,
     },
-    BeaconProviderArgs, DatabaseArgs, EngineDriverArgs, GasPriceOracleArgs, L1ProviderArgs,
-    NetworkArgs, ScrollRollupNode, ScrollRollupNodeConfig, SequencerArgs,
+    BeaconProviderArgs, ConsensusArgs, DatabaseArgs, EngineDriverArgs, GasPriceOracleArgs,
+    L1ProviderArgs, NetworkArgs, ScrollRollupNode, ScrollRollupNodeConfig, SequencerArgs,
 };
 use rollup_node_manager::{RollupManagerCommand, RollupManagerEvent};
 use rollup_node_providers::BlobSource;
@@ -59,6 +59,7 @@ async fn test_should_consolidate_to_block_15k() -> eyre::Result<()> {
         },
         signer_args: Default::default(),
         gas_price_oracle_args: GasPriceOracleArgs::default(),
+        consensus_args: ConsensusArgs::noop(),
     };
 
     let chain_spec = (*SCROLL_SEPOLIA).clone();

--- a/crates/sequencer/tests/e2e.rs
+++ b/crates/sequencer/tests/e2e.rs
@@ -10,8 +10,8 @@ use reth_scroll_chainspec::SCROLL_DEV;
 use reth_scroll_node::test_utils::setup;
 use rollup_node::{
     test_utils::{default_test_scroll_rollup_node_config, setup_engine},
-    BeaconProviderArgs, DatabaseArgs, EngineDriverArgs, GasPriceOracleArgs, L1ProviderArgs,
-    NetworkArgs, ScrollRollupNodeConfig, SequencerArgs, SignerArgs,
+    BeaconProviderArgs, ConsensusArgs, DatabaseArgs, EngineDriverArgs, GasPriceOracleArgs,
+    L1ProviderArgs, NetworkArgs, ScrollRollupNodeConfig, SequencerArgs, SignerArgs,
 };
 use rollup_node_manager::RollupManagerEvent;
 use rollup_node_primitives::{sig_encode_hash, BlockInfo, L1MessageEnvelope};
@@ -453,8 +453,10 @@ async fn can_sequence_blocks_with_private_key_file() -> eyre::Result<()> {
         signer_args: SignerArgs {
             key_file: Some(temp_file.path().to_path_buf()),
             aws_kms_key_id: None,
+            private_key: None,
         },
         gas_price_oracle_args: GasPriceOracleArgs::default(),
+        consensus_args: ConsensusArgs::noop(),
     };
 
     let (nodes, _tasks, wallet) =
@@ -542,8 +544,10 @@ async fn can_sequence_blocks_with_hex_key_file_without_prefix() -> eyre::Result<
         signer_args: SignerArgs {
             key_file: Some(temp_file.path().to_path_buf()),
             aws_kms_key_id: None,
+            private_key: None,
         },
         gas_price_oracle_args: GasPriceOracleArgs::default(),
+        consensus_args: ConsensusArgs::noop(),
     };
 
     let (nodes, _tasks, wallet) =

--- a/crates/signer/Cargo.toml
+++ b/crates/signer/Cargo.toml
@@ -11,6 +11,7 @@ workspace = true
 
 [dependencies]
 # alloy
+alloy-primitives.workspace = true
 alloy-signer.workspace = true
 
 # reth-scroll

--- a/crates/signer/src/handle.rs
+++ b/crates/signer/src/handle.rs
@@ -1,3 +1,4 @@
+use alloy_primitives::Address;
 use futures::{stream::StreamExt, Stream};
 use tokio::sync::mpsc::UnboundedSender;
 use tokio_stream::wrappers::UnboundedReceiverStream;
@@ -11,6 +12,8 @@ pub struct SignerHandle {
     pub request_tx: UnboundedSender<SignerRequest>,
     /// A channel to receive events from the signer.
     pub event_rx: UnboundedReceiverStream<SignerEvent>,
+    /// The signer address.
+    pub address: Address,
 }
 
 impl SignerHandle {
@@ -18,8 +21,9 @@ impl SignerHandle {
     pub const fn new(
         request_tx: UnboundedSender<SignerRequest>,
         event_rx: UnboundedReceiverStream<SignerEvent>,
+        address: Address,
     ) -> Self {
-        Self { request_tx, event_rx }
+        Self { request_tx, event_rx, address }
     }
 
     /// Sends a request to sign a block.

--- a/crates/signer/src/lib.rs
+++ b/crates/signer/src/lib.rs
@@ -50,6 +50,7 @@ impl Signer {
     fn new(signer: impl alloy_signer::Signer + Send + Sync + 'static) -> (Self, SignerHandle) {
         let (req_tx, req_rx) = tokio::sync::mpsc::unbounded_channel();
         let (event_tx, event_rx) = tokio::sync::mpsc::unbounded_channel();
+        let address = signer.address();
         let signer = Self {
             signer: Arc::new(signer),
             requests: req_rx.into(),
@@ -57,7 +58,7 @@ impl Signer {
             sender: event_tx,
             metrics: SignerMetrics::default(),
         };
-        (signer, SignerHandle::new(req_tx, event_rx.into()))
+        (signer, SignerHandle::new(req_tx, event_rx.into(), address))
     }
 
     /// Spawns a new `Signer` instance onto the tokio runtime.

--- a/tests/launch_rollup_node_follower.bash
+++ b/tests/launch_rollup_node_follower.bash
@@ -9,4 +9,5 @@ exec rollup-node node --chain dev --datadir=/l2reth --metrics=0.0.0.0:6060 --net
   --txpool.pending-max-count=1000 \
   --builder.gaslimit=20000000 \
   --rpc.max-connections=5000 \
-  --trusted-peers enode://3983278a7cab48862d9ab3187278edf376a0736a7deb55472a5650592f6922ce626a1ea7d74b77b9a679694b343f5e93ea97d5d60a9db4e4b51bb0c23a36d01b@rollup-node-sequencer:30303
+  --trusted-peers enode://3983278a7cab48862d9ab3187278edf376a0736a7deb55472a5650592f6922ce626a1ea7d74b77b9a679694b343f5e93ea97d5d60a9db4e4b51bb0c23a36d01b@rollup-node-sequencer:30303 \
+  --consensus.algorithm=noop

--- a/tests/launch_rollup_node_sequencer.bash
+++ b/tests/launch_rollup_node_sequencer.bash
@@ -11,4 +11,5 @@ exec rollup-node node --chain dev --datadir=/l2reth --metrics=0.0.0.0:6060 --net
   --sequencer.payload-building-duration 230 \
   --txpool.pending-max-count=1000 \
   --builder.gaslimit=20000000 \
-  --rpc.max-connections=5000
+  --rpc.max-connections=5000 \
+  --consensus.algorithm=noop


### PR DESCRIPTION
# Overview
This PR introduces a `should_sequence_block` on the `Consensus` trait such that the manager can asses if the sequencer is authorized to sign a new block for a specific slot. 