### PR TITLE
refactor: make tx forwarding to sequencer non-blocking if tx propagation enabled

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -151,14 +151,14 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b6093bc69509849435a2d68237a2e9fea79d27390c8e62f1e4012c460aabad8"
+checksum = "eda689f7287f15bd3582daba6be8d1545bad3740fd1fb778f629a1fe866bb43b"
 dependencies = [
- "alloy-eips 1.0.23",
+ "alloy-eips 1.0.24",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde 1.0.23",
+ "alloy-serde 1.0.24",
  "alloy-trie 0.9.0",
  "alloy-tx-macros",
  "arbitrary",
@@ -177,15 +177,15 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus-any"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d1cfed4fefd13b5620cb81cdb6ba397866ff0de514c1b24806e6e79cdff5570"
+checksum = "2b5659581e41e8fe350ecc3593cb5c9dcffddfd550896390f2b78a07af67b0fa"
 dependencies = [
- "alloy-consensus 1.0.23",
- "alloy-eips 1.0.23",
+ "alloy-consensus 1.0.24",
+ "alloy-eips 1.0.24",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde 1.0.23",
+ "alloy-serde 1.0.24",
  "arbitrary",
  "serde",
 ]
@@ -273,16 +273,16 @@ dependencies = [
 
 [[package]]
 name = "alloy-eips"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5937e2d544e9b71000942d875cbc57965b32859a666ea543cc57aae5a06d602d"
+checksum = "6f35887da30b5fc50267109a3c61cd63e6ca1f45967983641053a40ee83468c1"
 dependencies = [
  "alloy-eip2124",
  "alloy-eip2930",
  "alloy-eip7702",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde 1.0.23",
+ "alloy-serde 1.0.24",
  "arbitrary",
  "auto_impl",
  "c-kzg",
@@ -300,8 +300,8 @@ version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4042e855163839443cba91147fb7737c4aba02df4767cb322b0e8cea5a77642c"
 dependencies = [
- "alloy-consensus 1.0.23",
- "alloy-eips 1.0.23",
+ "alloy-consensus 1.0.24",
+ "alloy-eips 1.0.24",
  "alloy-hardforks",
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -316,13 +316,13 @@ dependencies = [
 
 [[package]]
 name = "alloy-genesis"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c51b4c13e02a8104170a4de02ccf006d7c233e6c10ab290ee16e7041e6ac221d"
+checksum = "11d4009efea6f403b3a80531f9c6f70fc242399498ff71196a1688cc1c901f44"
 dependencies = [
- "alloy-eips 1.0.23",
+ "alloy-eips 1.0.24",
  "alloy-primitives",
- "alloy-serde 1.0.23",
+ "alloy-serde 1.0.24",
  "alloy-trie 0.9.0",
  "serde",
  "serde_with",
@@ -356,9 +356,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-rpc"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b590caa6b6d8bc10e6e7a7696c59b1e550e89f27f50d1ee13071150d3a3e3f66"
+checksum = "883dee3b4020fcb5667ee627b4f401e899dad82bf37b246620339dd980720ed9"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -371,19 +371,19 @@ dependencies = [
 
 [[package]]
 name = "alloy-network"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36fe5af1fca03277daa56ad4ce5f6d623d3f4c2273ea30b9ee8674d18cefc1fa"
+checksum = "cd6e5b8ac1654a05c224390008e43634a2bdc74e181e02cf8ed591d8b3d4ad08"
 dependencies = [
- "alloy-consensus 1.0.23",
+ "alloy-consensus 1.0.24",
  "alloy-consensus-any",
- "alloy-eips 1.0.23",
+ "alloy-eips 1.0.24",
  "alloy-json-rpc",
  "alloy-network-primitives",
  "alloy-primitives",
  "alloy-rpc-types-any",
  "alloy-rpc-types-eth",
- "alloy-serde 1.0.23",
+ "alloy-serde 1.0.24",
  "alloy-signer",
  "alloy-sol-types",
  "async-trait",
@@ -397,14 +397,14 @@ dependencies = [
 
 [[package]]
 name = "alloy-network-primitives"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793df1e3457573877fbde8872e4906638fde565ee2d3bd16d04aad17d43dbf0e"
+checksum = "80d7980333dd9391719756ac28bc2afa9baa705fc70ffd11dc86ab078dd64477"
 dependencies = [
- "alloy-consensus 1.0.23",
- "alloy-eips 1.0.23",
+ "alloy-consensus 1.0.24",
+ "alloy-eips 1.0.24",
  "alloy-primitives",
- "alloy-serde 1.0.23",
+ "alloy-serde 1.0.24",
  "serde",
 ]
 
@@ -441,13 +441,13 @@ dependencies = [
 
 [[package]]
 name = "alloy-provider"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d59879a772ebdcde9dc4eb38b2535d32e8503d3175687cc09e763a625c5fcf32"
+checksum = "478a42fe167057b7b919cd8b0c2844f0247f667473340dad100eaf969de5754e"
 dependencies = [
  "alloy-chains",
- "alloy-consensus 1.0.23",
- "alloy-eips 1.0.23",
+ "alloy-consensus 1.0.24",
+ "alloy-eips 1.0.24",
  "alloy-json-rpc",
  "alloy-network",
  "alloy-network-primitives",
@@ -468,7 +468,6 @@ dependencies = [
  "either",
  "futures",
  "futures-utils-wasm",
- "http 1.3.1",
  "lru 0.13.0",
  "parking_lot 0.12.4",
  "pin-project",
@@ -484,13 +483,14 @@ dependencies = [
 
 [[package]]
 name = "alloy-pubsub"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbdfb2899b54b7cb0063fa8e61938320f9be6b81b681be69c203abf130a87baa"
+checksum = "b0a99b17987f40a066b29b6b56d75e84cd193b866cac27cae17b59f40338de95"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
  "alloy-transport",
+ "auto_impl",
  "bimap",
  "futures",
  "parking_lot 0.12.4",
@@ -527,9 +527,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-client"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f060e3bb9f319eb01867a2d6d1ff9e0114e8877f5ca8f5db447724136106cae"
+checksum = "8a0c6d723fbdf4a87454e2e3a275e161be27edcfbf46e2e3255dd66c138634b6"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -553,22 +553,22 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d47b637369245d2dafef84b223b1ff5ea59e6cd3a98d2d3516e32788a0b216df"
+checksum = "c41492dac39365b86a954de86c47ec23dcc7452cdb2fde591caadc194b3e34c6"
 dependencies = [
  "alloy-primitives",
- "alloy-rpc-types-engine 1.0.23",
+ "alloy-rpc-types-engine 1.0.24",
  "alloy-rpc-types-eth",
- "alloy-serde 1.0.23",
+ "alloy-serde 1.0.24",
  "serde",
 ]
 
 [[package]]
 name = "alloy-rpc-types-admin"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db29bf8f7c961533b017f383122cab6517c8da95712cf832e23c60415d520a58"
+checksum = "9c0f415ad97cc68d2f49eb08214f45c6827a6932a69773594f4ce178f8a41dc0"
 dependencies = [
  "alloy-genesis",
  "alloy-primitives",
@@ -578,25 +578,25 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-anvil"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0b1f499acb3fc729615147bc113b8b798b17379f19d43058a687edc5792c102"
+checksum = "10493fa300a2757d8134f584800fef545c15905c95122bed1f6dde0b0d9dae27"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
- "alloy-serde 1.0.23",
+ "alloy-serde 1.0.24",
  "serde",
 ]
 
 [[package]]
 name = "alloy-rpc-types-any"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e26b4dd90b33bd158975307fb9cf5fafa737a0e33cbb772a8648bf8be13c104"
+checksum = "8f7eb22670a972ad6c222a6c6dac3eef905579acffe9d63ab42be24c7d158535"
 dependencies = [
  "alloy-consensus-any",
  "alloy-rpc-types-eth",
- "alloy-serde 1.0.23",
+ "alloy-serde 1.0.24",
 ]
 
 [[package]]
@@ -615,13 +615,13 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-beacon"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9196cbbf4b82a3cc0c471a8e68ccb30102170d930948ac940d2bceadc1b1346b"
+checksum = "53381ffba0110a8aed4c9f108ef34a382ed21aeefb5f50f91c73451ae68b89aa"
 dependencies = [
- "alloy-eips 1.0.23",
+ "alloy-eips 1.0.24",
  "alloy-primitives",
- "alloy-rpc-types-engine 1.0.23",
+ "alloy-rpc-types-engine 1.0.24",
  "ethereum_ssz",
  "ethereum_ssz_derive",
  "serde",
@@ -633,11 +633,12 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-debug"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71841e6fc8e221892035a74f7d5b279c0a2bf27a7e1c93e7476c64ce9056624e"
+checksum = "a9b6f0482c82310366ec3dcf4e5212242f256a69fcf1a26e5017e6704091ee95"
 dependencies = [
  "alloy-primitives",
+ "derive_more",
  "serde",
 ]
 
@@ -660,15 +661,15 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-engine"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f9cbf5f781b9ee39cfdddea078fdef6015424f4c8282ef0e5416d15ca352c4"
+checksum = "e24c171377c0684e3860385f6d93fbfcc8ecc74f6cce8304c822bf1a50bacce0"
 dependencies = [
- "alloy-consensus 1.0.23",
- "alloy-eips 1.0.23",
+ "alloy-consensus 1.0.24",
+ "alloy-eips 1.0.24",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde 1.0.23",
+ "alloy-serde 1.0.24",
  "arbitrary",
  "derive_more",
  "ethereum_ssz",
@@ -681,17 +682,17 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-eth"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46586ec3c278639fc0e129f0eb73dbfa3d57f683c44b2ff5e066fab7ba63fa1f"
+checksum = "b777b98526bbe5b7892ca22a7fd5f18ed624ff664a79f40d0f9f2bf94ba79a84"
 dependencies = [
- "alloy-consensus 1.0.23",
+ "alloy-consensus 1.0.24",
  "alloy-consensus-any",
- "alloy-eips 1.0.23",
+ "alloy-eips 1.0.24",
  "alloy-network-primitives",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde 1.0.23",
+ "alloy-serde 1.0.24",
  "alloy-sol-types",
  "arbitrary",
  "itertools 0.14.0",
@@ -703,28 +704,28 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-mev"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79b6e80b501842c3f5803dd5752ae41b61f43bf6d2e1b8d29999d3312d67a8a5"
+checksum = "c15e8ccb6c16e196fcc968e16a71cd8ce4160f3ec5871d2ea196b75bf569ac02"
 dependencies = [
- "alloy-consensus 1.0.23",
- "alloy-eips 1.0.23",
+ "alloy-consensus 1.0.24",
+ "alloy-eips 1.0.24",
  "alloy-primitives",
  "alloy-rpc-types-eth",
- "alloy-serde 1.0.23",
+ "alloy-serde 1.0.24",
  "serde",
  "serde_json",
 ]
 
 [[package]]
 name = "alloy-rpc-types-trace"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc9a2184493c374ca1dbba9569d37215c23e489970f8c3994f731cb3ed6b0b7d"
+checksum = "d6a854af3fe8fce1cfe319fcf84ee8ba8cda352b14d3dd4221405b5fc6cce9e1"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
- "alloy-serde 1.0.23",
+ "alloy-serde 1.0.24",
  "serde",
  "serde_json",
  "thiserror 2.0.12",
@@ -732,13 +733,13 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-txpool"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3aaf142f4f6c0bdd06839c422179bae135024407d731e6f365380f88cd4730e"
+checksum = "3cc803e9b8d16154c856a738c376e002abe4b388e5fef91c8aebc8373e99fd45"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
- "alloy-serde 1.0.23",
+ "alloy-serde 1.0.24",
  "serde",
 ]
 
@@ -766,9 +767,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-serde"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e1722bc30feef87cc0fa824e43c9013f9639cc6c037be7be28a31361c788be2"
+checksum = "ee8d2c52adebf3e6494976c8542fbdf12f10123b26e11ad56f77274c16a2a039"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -778,9 +779,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3674beb29e68fbbc7be302b611cf35fe07b736e308012a280861df5a2361395"
+checksum = "7c0494d1e0f802716480aabbe25549c7f6bc2a25ff33b08fd332bbb4b7d06894"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -793,11 +794,11 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-aws"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "605b1659b320b16708bb84b41038b2f0e2a60d90972c28319c4f5a4866f0efd4"
+checksum = "0559495d87c099f7dbd0804145032e6a16ee675d1d2a15e98dc2658d64265cde"
 dependencies = [
- "alloy-consensus 1.0.23",
+ "alloy-consensus 1.0.24",
  "alloy-network",
  "alloy-primitives",
  "alloy-signer",
@@ -811,11 +812,11 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-local"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad7094c39cd41b03ed642145b0bd37251e31a9cf2ed19e1ce761f089867356a6"
+checksum = "59c2435eb8979a020763ced3fb478932071c56e5f75ea86db41f320915d325ba"
 dependencies = [
- "alloy-consensus 1.0.23",
+ "alloy-consensus 1.0.24",
  "alloy-network",
  "alloy-primitives",
  "alloy-signer",
@@ -899,12 +900,13 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f89bec2f59a41c0e259b6fe92f78dfc49862c17d10f938db9c33150d5a7f42b6"
+checksum = "3c0107675e10c7f248bf7273c1e7fdb02409a717269cc744012e6f3c39959bfb"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
+ "auto_impl",
  "base64 0.22.1",
  "derive_more",
  "futures",
@@ -922,12 +924,12 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-http"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d3615ec64d775fec840f4e9d5c8e1f739eb1854d8d28db093fb3d4805e0cb53"
+checksum = "78e3736701b5433afd06eecff08f0688a71a10e0e1352e0bbf0bed72f0dd4e35"
 dependencies = [
  "alloy-json-rpc",
- "alloy-rpc-types-engine 1.0.23",
+ "alloy-rpc-types-engine 1.0.24",
  "alloy-transport",
  "http-body-util",
  "hyper 1.6.0",
@@ -943,9 +945,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-ipc"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "374db72669d8ee09063b9aa1a316e812d5cdfce7fc9a99a3eceaa0e5512300d2"
+checksum = "c79064b5a08259581cb5614580010007c2df6deab1e8f3e8c7af8d7e9227008f"
 dependencies = [
  "alloy-json-rpc",
  "alloy-pubsub",
@@ -963,9 +965,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-ws"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5dbaa6851875d59c8803088f4b6ec72eaeddf7667547ae8995c1a19fbca6303"
+checksum = "77fd607158cb9bc54cbcfcaab4c5f36c5b26994c7dc58b6f095ce27a54f270f3"
 dependencies = [
  "alloy-pubsub",
  "alloy-transport",
@@ -1017,9 +1019,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-tx-macros"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f916ff6d52f219c44a9684aea764ce2c7e1d53bd4a724c9b127863aeacc30bb"
+checksum = "6acb36318dfa50817154064fea7932adf2eec3f51c86680e2b37d7e8906c66bb"
 dependencies = [
  "alloy-primitives",
  "darling",
@@ -5959,11 +5961,11 @@ version = "0.18.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c88d2940558fd69f8f07b3cbd7bb3c02fc7d31159c1a7ba9deede50e7881024"
 dependencies = [
- "alloy-consensus 1.0.23",
- "alloy-eips 1.0.23",
+ "alloy-consensus 1.0.24",
+ "alloy-eips 1.0.24",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde 1.0.23",
+ "alloy-serde 1.0.24",
  "arbitrary",
  "derive_more",
  "serde",
@@ -5977,12 +5979,12 @@ version = "0.18.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2b4f977b51e9e177e69a4d241ab7c4b439df9a3a5a998c000ae01be724de271"
 dependencies = [
- "alloy-consensus 1.0.23",
- "alloy-eips 1.0.23",
+ "alloy-consensus 1.0.24",
+ "alloy-eips 1.0.24",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-rpc-types-engine 1.0.23",
- "alloy-serde 1.0.23",
+ "alloy-rpc-types-engine 1.0.24",
+ "alloy-serde 1.0.24",
  "derive_more",
  "ethereum_ssz",
  "ethereum_ssz_derive",
@@ -7108,10 +7110,10 @@ checksum = "95325155c684b1c89f7765e30bc1c42e4a6da51ca513615660cb8a62ef9a88e3"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#72647dffbe31cb3fcbb03a1e5a91fc6c6eac8d42"
 dependencies = [
- "alloy-consensus 1.0.23",
- "alloy-eips 1.0.23",
+ "alloy-consensus 1.0.24",
+ "alloy-eips 1.0.24",
  "alloy-primitives",
  "futures-core",
  "futures-util",
@@ -7132,10 +7134,10 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#72647dffbe31cb3fcbb03a1e5a91fc6c6eac8d42"
 dependencies = [
- "alloy-consensus 1.0.23",
- "alloy-eips 1.0.23",
+ "alloy-consensus 1.0.24",
+ "alloy-eips 1.0.24",
  "alloy-primitives",
  "alloy-signer",
  "alloy-signer-local",
@@ -7163,11 +7165,11 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#72647dffbe31cb3fcbb03a1e5a91fc6c6eac8d42"
 dependencies = [
  "alloy-chains",
- "alloy-consensus 1.0.23",
- "alloy-eips 1.0.23",
+ "alloy-consensus 1.0.24",
+ "alloy-eips 1.0.24",
  "alloy-evm",
  "alloy-genesis",
  "alloy-primitives",
@@ -7183,7 +7185,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#72647dffbe31cb3fcbb03a1e5a91fc6c6eac8d42"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -7197,12 +7199,12 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#72647dffbe31cb3fcbb03a1e5a91fc6c6eac8d42"
 dependencies = [
  "ahash 0.8.12",
  "alloy-chains",
- "alloy-consensus 1.0.23",
- "alloy-eips 1.0.23",
+ "alloy-consensus 1.0.24",
+ "alloy-eips 1.0.24",
  "alloy-primitives",
  "alloy-rlp",
  "backon",
@@ -7270,7 +7272,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#72647dffbe31cb3fcbb03a1e5a91fc6c6eac8d42"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -7280,9 +7282,9 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#72647dffbe31cb3fcbb03a1e5a91fc6c6eac8d42"
 dependencies = [
- "alloy-eips 1.0.23",
+ "alloy-eips 1.0.24",
  "alloy-primitives",
  "cfg-if",
  "eyre",
@@ -7297,10 +7299,10 @@ dependencies = [
 [[package]]
 name = "reth-codecs"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#72647dffbe31cb3fcbb03a1e5a91fc6c6eac8d42"
 dependencies = [
- "alloy-consensus 1.0.23",
- "alloy-eips 1.0.23",
+ "alloy-consensus 1.0.24",
+ "alloy-eips 1.0.24",
  "alloy-genesis",
  "alloy-primitives",
  "alloy-trie 0.9.0",
@@ -7317,7 +7319,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs-derive"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#72647dffbe31cb3fcbb03a1e5a91fc6c6eac8d42"
 dependencies = [
  "convert_case",
  "proc-macro2",
@@ -7328,7 +7330,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#72647dffbe31cb3fcbb03a1e5a91fc6c6eac8d42"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -7343,9 +7345,9 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#72647dffbe31cb3fcbb03a1e5a91fc6c6eac8d42"
 dependencies = [
- "alloy-consensus 1.0.23",
+ "alloy-consensus 1.0.24",
  "alloy-primitives",
  "auto_impl",
  "reth-execution-types",
@@ -7356,10 +7358,10 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#72647dffbe31cb3fcbb03a1e5a91fc6c6eac8d42"
 dependencies = [
- "alloy-consensus 1.0.23",
- "alloy-eips 1.0.23",
+ "alloy-consensus 1.0.24",
+ "alloy-eips 1.0.24",
  "reth-chainspec",
  "reth-consensus",
  "reth-primitives-traits",
@@ -7368,14 +7370,14 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#72647dffbe31cb3fcbb03a1e5a91fc6c6eac8d42"
 dependencies = [
- "alloy-consensus 1.0.23",
- "alloy-eips 1.0.23",
+ "alloy-consensus 1.0.24",
+ "alloy-eips 1.0.24",
  "alloy-json-rpc",
  "alloy-primitives",
  "alloy-provider",
- "alloy-rpc-types-engine 1.0.23",
+ "alloy-rpc-types-engine 1.0.24",
  "auto_impl",
  "derive_more",
  "eyre",
@@ -7393,7 +7395,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#72647dffbe31cb3fcbb03a1e5a91fc6c6eac8d42"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -7419,9 +7421,9 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#72647dffbe31cb3fcbb03a1e5a91fc6c6eac8d42"
 dependencies = [
- "alloy-consensus 1.0.23",
+ "alloy-consensus 1.0.24",
  "alloy-genesis",
  "alloy-primitives",
  "arbitrary",
@@ -7448,9 +7450,9 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#72647dffbe31cb3fcbb03a1e5a91fc6c6eac8d42"
 dependencies = [
- "alloy-consensus 1.0.23",
+ "alloy-consensus 1.0.24",
  "alloy-genesis",
  "alloy-primitives",
  "boyer-moore-magiclen",
@@ -7477,9 +7479,9 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#72647dffbe31cb3fcbb03a1e5a91fc6c6eac8d42"
 dependencies = [
- "alloy-eips 1.0.23",
+ "alloy-eips 1.0.24",
  "alloy-primitives",
  "arbitrary",
  "bytes",
@@ -7492,7 +7494,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#72647dffbe31cb3fcbb03a1e5a91fc6c6eac8d42"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -7518,7 +7520,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#72647dffbe31cb3fcbb03a1e5a91fc6c6eac8d42"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -7542,7 +7544,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#72647dffbe31cb3fcbb03a1e5a91fc6c6eac8d42"
 dependencies = [
  "alloy-primitives",
  "data-encoding",
@@ -7566,10 +7568,10 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#72647dffbe31cb3fcbb03a1e5a91fc6c6eac8d42"
 dependencies = [
- "alloy-consensus 1.0.23",
- "alloy-eips 1.0.23",
+ "alloy-consensus 1.0.24",
+ "alloy-eips 1.0.24",
  "alloy-primitives",
  "alloy-rlp",
  "futures",
@@ -7601,16 +7603,16 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#72647dffbe31cb3fcbb03a1e5a91fc6c6eac8d42"
 dependencies = [
- "alloy-consensus 1.0.23",
- "alloy-eips 1.0.23",
+ "alloy-consensus 1.0.24",
+ "alloy-eips 1.0.24",
  "alloy-genesis",
  "alloy-network",
  "alloy-primitives",
  "alloy-provider",
  "alloy-rlp",
- "alloy-rpc-types-engine 1.0.23",
+ "alloy-rpc-types-engine 1.0.24",
  "alloy-rpc-types-eth",
  "alloy-signer",
  "alloy-signer-local",
@@ -7663,7 +7665,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#72647dffbe31cb3fcbb03a1e5a91fc6c6eac8d42"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -7694,11 +7696,11 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#72647dffbe31cb3fcbb03a1e5a91fc6c6eac8d42"
 dependencies = [
- "alloy-consensus 1.0.23",
+ "alloy-consensus 1.0.24",
  "alloy-primitives",
- "alloy-rpc-types-engine 1.0.23",
+ "alloy-rpc-types-engine 1.0.24",
  "eyre",
  "futures-util",
  "reth-chainspec",
@@ -7717,12 +7719,12 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#72647dffbe31cb3fcbb03a1e5a91fc6c6eac8d42"
 dependencies = [
- "alloy-consensus 1.0.23",
- "alloy-eips 1.0.23",
+ "alloy-consensus 1.0.24",
+ "alloy-eips 1.0.24",
  "alloy-primitives",
- "alloy-rpc-types-engine 1.0.23",
+ "alloy-rpc-types-engine 1.0.24",
  "auto_impl",
  "futures",
  "reth-chain-state",
@@ -7742,7 +7744,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-service"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#72647dffbe31cb3fcbb03a1e5a91fc6c6eac8d42"
 dependencies = [
  "futures",
  "pin-project",
@@ -7765,14 +7767,14 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#72647dffbe31cb3fcbb03a1e5a91fc6c6eac8d42"
 dependencies = [
- "alloy-consensus 1.0.23",
- "alloy-eips 1.0.23",
+ "alloy-consensus 1.0.24",
+ "alloy-eips 1.0.24",
  "alloy-evm",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-rpc-types-engine 1.0.23",
+ "alloy-rpc-types-engine 1.0.24",
  "derive_more",
  "futures",
  "itertools 0.14.0",
@@ -7818,10 +7820,10 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#72647dffbe31cb3fcbb03a1e5a91fc6c6eac8d42"
 dependencies = [
- "alloy-consensus 1.0.23",
- "alloy-rpc-types-engine 1.0.23",
+ "alloy-consensus 1.0.24",
+ "alloy-rpc-types-engine 1.0.24",
  "eyre",
  "futures",
  "itertools 0.14.0",
@@ -7845,10 +7847,10 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#72647dffbe31cb3fcbb03a1e5a91fc6c6eac8d42"
 dependencies = [
- "alloy-consensus 1.0.23",
- "alloy-eips 1.0.23",
+ "alloy-consensus 1.0.24",
+ "alloy-eips 1.0.24",
  "alloy-primitives",
  "alloy-rlp",
  "ethereum_ssz",
@@ -7861,7 +7863,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#72647dffbe31cb3fcbb03a1e5a91fc6c6eac8d42"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -7876,9 +7878,9 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#72647dffbe31cb3fcbb03a1e5a91fc6c6eac8d42"
 dependencies = [
- "alloy-consensus 1.0.23",
+ "alloy-consensus 1.0.24",
  "alloy-primitives",
  "alloy-rlp",
  "eyre",
@@ -7900,7 +7902,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#72647dffbe31cb3fcbb03a1e5a91fc6c6eac8d42"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -7911,7 +7913,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#72647dffbe31cb3fcbb03a1e5a91fc6c6eac8d42"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -7939,11 +7941,11 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#72647dffbe31cb3fcbb03a1e5a91fc6c6eac8d42"
 dependencies = [
  "alloy-chains",
- "alloy-consensus 1.0.23",
- "alloy-eips 1.0.23",
+ "alloy-consensus 1.0.24",
+ "alloy-eips 1.0.24",
  "alloy-hardforks",
  "alloy-primitives",
  "alloy-rlp",
@@ -7960,10 +7962,10 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#72647dffbe31cb3fcbb03a1e5a91fc6c6eac8d42"
 dependencies = [
- "alloy-consensus 1.0.23",
- "alloy-eips 1.0.23",
+ "alloy-consensus 1.0.24",
+ "alloy-eips 1.0.24",
  "alloy-primitives",
  "reth-chainspec",
  "reth-consensus",
@@ -7976,12 +7978,12 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#72647dffbe31cb3fcbb03a1e5a91fc6c6eac8d42"
 dependencies = [
- "alloy-eips 1.0.23",
+ "alloy-eips 1.0.24",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-rpc-types-engine 1.0.23",
+ "alloy-rpc-types-engine 1.0.24",
  "reth-engine-primitives",
  "reth-ethereum-primitives",
  "reth-payload-primitives",
@@ -7994,7 +7996,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#72647dffbe31cb3fcbb03a1e5a91fc6c6eac8d42"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -8008,12 +8010,12 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#72647dffbe31cb3fcbb03a1e5a91fc6c6eac8d42"
 dependencies = [
- "alloy-consensus 1.0.23",
- "alloy-eips 1.0.23",
+ "alloy-consensus 1.0.24",
+ "alloy-eips 1.0.24",
  "alloy-primitives",
- "alloy-rpc-types-engine 1.0.23",
+ "alloy-rpc-types-engine 1.0.24",
  "reth-basic-payload-builder",
  "reth-chainspec",
  "reth-errors",
@@ -8035,10 +8037,10 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#72647dffbe31cb3fcbb03a1e5a91fc6c6eac8d42"
 dependencies = [
- "alloy-consensus 1.0.23",
- "alloy-eips 1.0.23",
+ "alloy-consensus 1.0.24",
+ "alloy-eips 1.0.24",
  "alloy-primitives",
  "alloy-rlp",
  "arbitrary",
@@ -8053,7 +8055,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#72647dffbe31cb3fcbb03a1e5a91fc6c6eac8d42"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -8063,10 +8065,10 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#72647dffbe31cb3fcbb03a1e5a91fc6c6eac8d42"
 dependencies = [
- "alloy-consensus 1.0.23",
- "alloy-eips 1.0.23",
+ "alloy-consensus 1.0.24",
+ "alloy-eips 1.0.24",
  "alloy-evm",
  "alloy-primitives",
  "auto_impl",
@@ -8087,10 +8089,10 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#72647dffbe31cb3fcbb03a1e5a91fc6c6eac8d42"
 dependencies = [
- "alloy-consensus 1.0.23",
- "alloy-eips 1.0.23",
+ "alloy-consensus 1.0.24",
+ "alloy-eips 1.0.24",
  "alloy-evm",
  "alloy-primitives",
  "reth-chainspec",
@@ -8105,7 +8107,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#72647dffbe31cb3fcbb03a1e5a91fc6c6eac8d42"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -8118,10 +8120,10 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#72647dffbe31cb3fcbb03a1e5a91fc6c6eac8d42"
 dependencies = [
- "alloy-consensus 1.0.23",
- "alloy-eips 1.0.23",
+ "alloy-consensus 1.0.24",
+ "alloy-eips 1.0.24",
  "alloy-evm",
  "alloy-primitives",
  "derive_more",
@@ -8136,10 +8138,10 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#72647dffbe31cb3fcbb03a1e5a91fc6c6eac8d42"
 dependencies = [
- "alloy-consensus 1.0.23",
- "alloy-eips 1.0.23",
+ "alloy-consensus 1.0.24",
+ "alloy-eips 1.0.24",
  "alloy-primitives",
  "eyre",
  "futures",
@@ -8174,9 +8176,9 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#72647dffbe31cb3fcbb03a1e5a91fc6c6eac8d42"
 dependencies = [
- "alloy-eips 1.0.23",
+ "alloy-eips 1.0.24",
  "alloy-primitives",
  "reth-chain-state",
  "reth-execution-types",
@@ -8188,7 +8190,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#72647dffbe31cb3fcbb03a1e5a91fc6c6eac8d42"
 dependencies = [
  "serde",
  "serde_json",
@@ -8198,9 +8200,9 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#72647dffbe31cb3fcbb03a1e5a91fc6c6eac8d42"
 dependencies = [
- "alloy-consensus 1.0.23",
+ "alloy-consensus 1.0.24",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-rpc-types-debug",
@@ -8226,7 +8228,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#72647dffbe31cb3fcbb03a1e5a91fc6c6eac8d42"
 dependencies = [
  "bytes",
  "futures",
@@ -8246,7 +8248,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#72647dffbe31cb3fcbb03a1e5a91fc6c6eac8d42"
 dependencies = [
  "bitflags 2.9.1",
  "byteorder",
@@ -8263,7 +8265,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#72647dffbe31cb3fcbb03a1e5a91fc6c6eac8d42"
 dependencies = [
  "bindgen 0.70.1",
  "cc",
@@ -8272,7 +8274,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#72647dffbe31cb3fcbb03a1e5a91fc6c6eac8d42"
 dependencies = [
  "futures",
  "metrics",
@@ -8284,7 +8286,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#72647dffbe31cb3fcbb03a1e5a91fc6c6eac8d42"
 dependencies = [
  "alloy-primitives",
 ]
@@ -8292,7 +8294,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#72647dffbe31cb3fcbb03a1e5a91fc6c6eac8d42"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -8306,10 +8308,10 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#72647dffbe31cb3fcbb03a1e5a91fc6c6eac8d42"
 dependencies = [
- "alloy-consensus 1.0.23",
- "alloy-eips 1.0.23",
+ "alloy-consensus 1.0.24",
+ "alloy-eips 1.0.24",
  "alloy-primitives",
  "alloy-rlp",
  "aquamarine",
@@ -8361,9 +8363,9 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#72647dffbe31cb3fcbb03a1e5a91fc6c6eac8d42"
 dependencies = [
- "alloy-consensus 1.0.23",
+ "alloy-consensus 1.0.24",
  "alloy-primitives",
  "alloy-rpc-types-admin",
  "alloy-rpc-types-eth",
@@ -8387,10 +8389,10 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#72647dffbe31cb3fcbb03a1e5a91fc6c6eac8d42"
 dependencies = [
- "alloy-consensus 1.0.23",
- "alloy-eips 1.0.23",
+ "alloy-consensus 1.0.24",
+ "alloy-eips 1.0.24",
  "alloy-primitives",
  "auto_impl",
  "derive_more",
@@ -8410,7 +8412,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#72647dffbe31cb3fcbb03a1e5a91fc6c6eac8d42"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8425,7 +8427,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#72647dffbe31cb3fcbb03a1e5a91fc6c6eac8d42"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -8439,7 +8441,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#72647dffbe31cb3fcbb03a1e5a91fc6c6eac8d42"
 dependencies = [
  "anyhow",
  "bincode",
@@ -8456,9 +8458,9 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#72647dffbe31cb3fcbb03a1e5a91fc6c6eac8d42"
 dependencies = [
- "alloy-rpc-types-engine 1.0.23",
+ "alloy-rpc-types-engine 1.0.24",
  "eyre",
  "reth-basic-payload-builder",
  "reth-consensus",
@@ -8480,14 +8482,14 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#72647dffbe31cb3fcbb03a1e5a91fc6c6eac8d42"
 dependencies = [
- "alloy-consensus 1.0.23",
- "alloy-eips 1.0.23",
+ "alloy-consensus 1.0.24",
+ "alloy-eips 1.0.24",
  "alloy-primitives",
  "alloy-provider",
  "alloy-rpc-types",
- "alloy-rpc-types-engine 1.0.23",
+ "alloy-rpc-types-engine 1.0.24",
  "aquamarine",
  "eyre",
  "fdlimit",
@@ -8546,12 +8548,12 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#72647dffbe31cb3fcbb03a1e5a91fc6c6eac8d42"
 dependencies = [
- "alloy-consensus 1.0.23",
- "alloy-eips 1.0.23",
+ "alloy-consensus 1.0.24",
+ "alloy-eips 1.0.24",
  "alloy-primitives",
- "alloy-rpc-types-engine 1.0.23",
+ "alloy-rpc-types-engine 1.0.24",
  "clap",
  "derive_more",
  "dirs-next",
@@ -8598,11 +8600,11 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#72647dffbe31cb3fcbb03a1e5a91fc6c6eac8d42"
 dependencies = [
- "alloy-eips 1.0.23",
+ "alloy-eips 1.0.24",
  "alloy-network",
- "alloy-rpc-types-engine 1.0.23",
+ "alloy-rpc-types-engine 1.0.24",
  "alloy-rpc-types-eth",
  "eyre",
  "reth-chainspec",
@@ -8636,9 +8638,9 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#72647dffbe31cb3fcbb03a1e5a91fc6c6eac8d42"
 dependencies = [
- "alloy-consensus 1.0.23",
+ "alloy-consensus 1.0.24",
  "alloy-primitives",
  "chrono",
  "futures-util",
@@ -8660,12 +8662,12 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#72647dffbe31cb3fcbb03a1e5a91fc6c6eac8d42"
 dependencies = [
- "alloy-consensus 1.0.23",
- "alloy-eips 1.0.23",
+ "alloy-consensus 1.0.24",
+ "alloy-eips 1.0.24",
  "alloy-primitives",
- "alloy-rpc-types-engine 1.0.23",
+ "alloy-rpc-types-engine 1.0.24",
  "derive_more",
  "futures",
  "humantime",
@@ -8684,7 +8686,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#72647dffbe31cb3fcbb03a1e5a91fc6c6eac8d42"
 dependencies = [
  "eyre",
  "http 1.3.1",
@@ -8704,7 +8706,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#72647dffbe31cb3fcbb03a1e5a91fc6c6eac8d42"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -8717,10 +8719,10 @@ dependencies = [
 [[package]]
 name = "reth-optimism-primitives"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#72647dffbe31cb3fcbb03a1e5a91fc6c6eac8d42"
 dependencies = [
- "alloy-consensus 1.0.23",
- "alloy-eips 1.0.23",
+ "alloy-consensus 1.0.24",
+ "alloy-eips 1.0.24",
  "alloy-primitives",
  "alloy-rlp",
  "arbitrary",
@@ -8736,9 +8738,9 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#72647dffbe31cb3fcbb03a1e5a91fc6c6eac8d42"
 dependencies = [
- "alloy-consensus 1.0.23",
+ "alloy-consensus 1.0.24",
  "alloy-primitives",
  "alloy-rpc-types",
  "futures-util",
@@ -8757,7 +8759,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#72647dffbe31cb3fcbb03a1e5a91fc6c6eac8d42"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -8769,11 +8771,11 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#72647dffbe31cb3fcbb03a1e5a91fc6c6eac8d42"
 dependencies = [
- "alloy-eips 1.0.23",
+ "alloy-eips 1.0.24",
  "alloy-primitives",
- "alloy-rpc-types-engine 1.0.23",
+ "alloy-rpc-types-engine 1.0.24",
  "auto_impl",
  "op-alloy-rpc-types-engine",
  "reth-chain-state",
@@ -8789,9 +8791,9 @@ dependencies = [
 [[package]]
 name = "reth-payload-util"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#72647dffbe31cb3fcbb03a1e5a91fc6c6eac8d42"
 dependencies = [
- "alloy-consensus 1.0.23",
+ "alloy-consensus 1.0.24",
  "alloy-primitives",
  "reth-transaction-pool",
 ]
@@ -8799,19 +8801,19 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#72647dffbe31cb3fcbb03a1e5a91fc6c6eac8d42"
 dependencies = [
- "alloy-consensus 1.0.23",
- "alloy-rpc-types-engine 1.0.23",
+ "alloy-consensus 1.0.24",
+ "alloy-rpc-types-engine 1.0.24",
  "reth-primitives-traits",
 ]
 
 [[package]]
 name = "reth-primitives"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#72647dffbe31cb3fcbb03a1e5a91fc6c6eac8d42"
 dependencies = [
- "alloy-consensus 1.0.23",
+ "alloy-consensus 1.0.24",
  "arbitrary",
  "c-kzg",
  "once_cell",
@@ -8824,10 +8826,10 @@ dependencies = [
 [[package]]
 name = "reth-primitives-traits"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#72647dffbe31cb3fcbb03a1e5a91fc6c6eac8d42"
 dependencies = [
- "alloy-consensus 1.0.23",
- "alloy-eips 1.0.23",
+ "alloy-consensus 1.0.24",
+ "alloy-eips 1.0.24",
  "alloy-genesis",
  "alloy-primitives",
  "alloy-rlp",
@@ -8858,12 +8860,12 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#72647dffbe31cb3fcbb03a1e5a91fc6c6eac8d42"
 dependencies = [
- "alloy-consensus 1.0.23",
- "alloy-eips 1.0.23",
+ "alloy-consensus 1.0.24",
+ "alloy-eips 1.0.24",
  "alloy-primitives",
- "alloy-rpc-types-engine 1.0.23",
+ "alloy-rpc-types-engine 1.0.24",
  "dashmap 6.1.0",
  "eyre",
  "itertools 0.14.0",
@@ -8903,10 +8905,10 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#72647dffbe31cb3fcbb03a1e5a91fc6c6eac8d42"
 dependencies = [
- "alloy-consensus 1.0.23",
- "alloy-eips 1.0.23",
+ "alloy-consensus 1.0.24",
+ "alloy-eips 1.0.24",
  "alloy-primitives",
  "itertools 0.14.0",
  "metrics",
@@ -8931,7 +8933,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#72647dffbe31cb3fcbb03a1e5a91fc6c6eac8d42"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -8945,7 +8947,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#72647dffbe31cb3fcbb03a1e5a91fc6c6eac8d42"
 dependencies = [
  "alloy-primitives",
  "reth-primitives-traits",
@@ -8958,11 +8960,11 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#72647dffbe31cb3fcbb03a1e5a91fc6c6eac8d42"
 dependencies = [
- "alloy-consensus 1.0.23",
+ "alloy-consensus 1.0.24",
  "alloy-dyn-abi",
- "alloy-eips 1.0.23",
+ "alloy-eips 1.0.24",
  "alloy-evm",
  "alloy-genesis",
  "alloy-network",
@@ -8970,14 +8972,14 @@ dependencies = [
  "alloy-rlp",
  "alloy-rpc-types",
  "alloy-rpc-types-admin",
- "alloy-rpc-types-beacon 1.0.23",
+ "alloy-rpc-types-beacon 1.0.24",
  "alloy-rpc-types-debug",
- "alloy-rpc-types-engine 1.0.23",
+ "alloy-rpc-types-engine 1.0.24",
  "alloy-rpc-types-eth",
  "alloy-rpc-types-mev",
  "alloy-rpc-types-trace",
  "alloy-rpc-types-txpool",
- "alloy-serde 1.0.23",
+ "alloy-serde 1.0.24",
  "alloy-signer",
  "alloy-signer-local",
  "async-trait",
@@ -9034,23 +9036,23 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#72647dffbe31cb3fcbb03a1e5a91fc6c6eac8d42"
 dependencies = [
- "alloy-eips 1.0.23",
+ "alloy-eips 1.0.24",
  "alloy-genesis",
  "alloy-json-rpc",
  "alloy-primitives",
  "alloy-rpc-types",
  "alloy-rpc-types-admin",
  "alloy-rpc-types-anvil",
- "alloy-rpc-types-beacon 1.0.23",
+ "alloy-rpc-types-beacon 1.0.24",
  "alloy-rpc-types-debug",
- "alloy-rpc-types-engine 1.0.23",
+ "alloy-rpc-types-engine 1.0.24",
  "alloy-rpc-types-eth",
  "alloy-rpc-types-mev",
  "alloy-rpc-types-trace",
  "alloy-rpc-types-txpool",
- "alloy-serde 1.0.23",
+ "alloy-serde 1.0.24",
  "jsonrpsee",
  "reth-chain-state",
  "reth-engine-primitives",
@@ -9062,7 +9064,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#72647dffbe31cb3fcbb03a1e5a91fc6c6eac8d42"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -9100,9 +9102,9 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#72647dffbe31cb3fcbb03a1e5a91fc6c6eac8d42"
 dependencies = [
- "alloy-consensus 1.0.23",
+ "alloy-consensus 1.0.24",
  "alloy-json-rpc",
  "alloy-network",
  "alloy-primitives",
@@ -9125,11 +9127,11 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#72647dffbe31cb3fcbb03a1e5a91fc6c6eac8d42"
 dependencies = [
- "alloy-eips 1.0.23",
+ "alloy-eips 1.0.24",
  "alloy-primitives",
- "alloy-rpc-types-engine 1.0.23",
+ "alloy-rpc-types-engine 1.0.24",
  "async-trait",
  "jsonrpsee-core",
  "jsonrpsee-types",
@@ -9155,11 +9157,11 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#72647dffbe31cb3fcbb03a1e5a91fc6c6eac8d42"
 dependencies = [
- "alloy-consensus 1.0.23",
+ "alloy-consensus 1.0.24",
  "alloy-dyn-abi",
- "alloy-eips 1.0.23",
+ "alloy-eips 1.0.24",
  "alloy-evm",
  "alloy-json-rpc",
  "alloy-network",
@@ -9167,7 +9169,7 @@ dependencies = [
  "alloy-rlp",
  "alloy-rpc-types-eth",
  "alloy-rpc-types-mev",
- "alloy-serde 1.0.23",
+ "alloy-serde 1.0.24",
  "async-trait",
  "auto_impl",
  "dyn-clone",
@@ -9200,10 +9202,10 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#72647dffbe31cb3fcbb03a1e5a91fc6c6eac8d42"
 dependencies = [
- "alloy-consensus 1.0.23",
- "alloy-eips 1.0.23",
+ "alloy-consensus 1.0.24",
+ "alloy-eips 1.0.24",
  "alloy-evm",
  "alloy-network",
  "alloy-primitives",
@@ -9244,9 +9246,9 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#72647dffbe31cb3fcbb03a1e5a91fc6c6eac8d42"
 dependencies = [
- "alloy-rpc-types-engine 1.0.23",
+ "alloy-rpc-types-engine 1.0.24",
  "http 1.3.1",
  "jsonrpsee-http-client",
  "pin-project",
@@ -9258,11 +9260,11 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#72647dffbe31cb3fcbb03a1e5a91fc6c6eac8d42"
 dependencies = [
- "alloy-eips 1.0.23",
+ "alloy-eips 1.0.24",
  "alloy-primitives",
- "alloy-rpc-types-engine 1.0.23",
+ "alloy-rpc-types-engine 1.0.24",
  "jsonrpsee-core",
  "jsonrpsee-types",
  "reth-errors",
@@ -9274,14 +9276,14 @@ dependencies = [
 [[package]]
 name = "reth-scroll-chainspec"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#72647dffbe31cb3fcbb03a1e5a91fc6c6eac8d42"
 dependencies = [
  "alloy-chains",
- "alloy-consensus 1.0.23",
- "alloy-eips 1.0.23",
+ "alloy-consensus 1.0.24",
+ "alloy-eips 1.0.24",
  "alloy-genesis",
  "alloy-primitives",
- "alloy-serde 1.0.23",
+ "alloy-serde 1.0.24",
  "auto_impl",
  "derive_more",
  "once_cell",
@@ -9299,7 +9301,7 @@ dependencies = [
 [[package]]
 name = "reth-scroll-cli"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#72647dffbe31cb3fcbb03a1e5a91fc6c6eac8d42"
 dependencies = [
  "clap",
  "eyre",
@@ -9323,9 +9325,9 @@ dependencies = [
 [[package]]
 name = "reth-scroll-consensus"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#72647dffbe31cb3fcbb03a1e5a91fc6c6eac8d42"
 dependencies = [
- "alloy-consensus 1.0.23",
+ "alloy-consensus 1.0.24",
  "alloy-primitives",
  "reth-chainspec",
  "reth-consensus",
@@ -9342,13 +9344,13 @@ dependencies = [
 [[package]]
 name = "reth-scroll-engine-primitives"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#72647dffbe31cb3fcbb03a1e5a91fc6c6eac8d42"
 dependencies = [
- "alloy-consensus 1.0.23",
- "alloy-eips 1.0.23",
+ "alloy-consensus 1.0.24",
+ "alloy-eips 1.0.24",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-rpc-types-engine 1.0.23",
+ "alloy-rpc-types-engine 1.0.24",
  "reth-chain-state",
  "reth-chainspec",
  "reth-engine-primitives",
@@ -9367,10 +9369,10 @@ dependencies = [
 [[package]]
 name = "reth-scroll-evm"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#72647dffbe31cb3fcbb03a1e5a91fc6c6eac8d42"
 dependencies = [
- "alloy-consensus 1.0.23",
- "alloy-eips 1.0.23",
+ "alloy-consensus 1.0.24",
+ "alloy-eips 1.0.24",
  "alloy-evm",
  "alloy-primitives",
  "derive_more",
@@ -9396,7 +9398,7 @@ dependencies = [
 [[package]]
 name = "reth-scroll-forks"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#72647dffbe31cb3fcbb03a1e5a91fc6c6eac8d42"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9410,12 +9412,12 @@ dependencies = [
 [[package]]
 name = "reth-scroll-node"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#72647dffbe31cb3fcbb03a1e5a91fc6c6eac8d42"
 dependencies = [
- "alloy-consensus 1.0.23",
+ "alloy-consensus 1.0.24",
  "alloy-genesis",
  "alloy-primitives",
- "alloy-rpc-types-engine 1.0.23",
+ "alloy-rpc-types-engine 1.0.24",
  "alloy-rpc-types-eth",
  "clap",
  "eyre",
@@ -9462,9 +9464,9 @@ dependencies = [
 [[package]]
 name = "reth-scroll-payload"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#72647dffbe31cb3fcbb03a1e5a91fc6c6eac8d42"
 dependencies = [
- "alloy-consensus 1.0.23",
+ "alloy-consensus 1.0.24",
  "alloy-primitives",
  "alloy-rlp",
  "futures-util",
@@ -9493,10 +9495,10 @@ dependencies = [
 [[package]]
 name = "reth-scroll-primitives"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#72647dffbe31cb3fcbb03a1e5a91fc6c6eac8d42"
 dependencies = [
- "alloy-consensus 1.0.23",
- "alloy-eips 1.0.23",
+ "alloy-consensus 1.0.24",
+ "alloy-eips 1.0.24",
  "alloy-primitives",
  "alloy-rlp",
  "arbitrary",
@@ -9513,10 +9515,10 @@ dependencies = [
 [[package]]
 name = "reth-scroll-rpc"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#72647dffbe31cb3fcbb03a1e5a91fc6c6eac8d42"
 dependencies = [
- "alloy-consensus 1.0.23",
- "alloy-eips 1.0.23",
+ "alloy-consensus 1.0.24",
+ "alloy-eips 1.0.24",
  "alloy-json-rpc",
  "alloy-primitives",
  "alloy-rpc-client",
@@ -9554,10 +9556,10 @@ dependencies = [
 [[package]]
 name = "reth-scroll-txpool"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#72647dffbe31cb3fcbb03a1e5a91fc6c6eac8d42"
 dependencies = [
- "alloy-consensus 1.0.23",
- "alloy-eips 1.0.23",
+ "alloy-consensus 1.0.24",
+ "alloy-eips 1.0.24",
  "alloy-primitives",
  "c-kzg",
  "derive_more",
@@ -9577,10 +9579,10 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#72647dffbe31cb3fcbb03a1e5a91fc6c6eac8d42"
 dependencies = [
- "alloy-consensus 1.0.23",
- "alloy-eips 1.0.23",
+ "alloy-consensus 1.0.24",
+ "alloy-eips 1.0.24",
  "alloy-primitives",
  "bincode",
  "blake3",
@@ -9627,9 +9629,9 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#72647dffbe31cb3fcbb03a1e5a91fc6c6eac8d42"
 dependencies = [
- "alloy-eips 1.0.23",
+ "alloy-eips 1.0.24",
  "alloy-primitives",
  "aquamarine",
  "auto_impl",
@@ -9654,7 +9656,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#72647dffbe31cb3fcbb03a1e5a91fc6c6eac8d42"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -9668,7 +9670,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#72647dffbe31cb3fcbb03a1e5a91fc6c6eac8d42"
 dependencies = [
  "alloy-primitives",
  "parking_lot 0.12.4",
@@ -9688,7 +9690,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#72647dffbe31cb3fcbb03a1e5a91fc6c6eac8d42"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -9700,12 +9702,12 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#72647dffbe31cb3fcbb03a1e5a91fc6c6eac8d42"
 dependencies = [
- "alloy-consensus 1.0.23",
- "alloy-eips 1.0.23",
+ "alloy-consensus 1.0.24",
+ "alloy-eips 1.0.24",
  "alloy-primitives",
- "alloy-rpc-types-engine 1.0.23",
+ "alloy-rpc-types-engine 1.0.24",
  "auto_impl",
  "reth-chainspec",
  "reth-db-api",
@@ -9724,9 +9726,9 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#72647dffbe31cb3fcbb03a1e5a91fc6c6eac8d42"
 dependencies = [
- "alloy-eips 1.0.23",
+ "alloy-eips 1.0.24",
  "alloy-primitives",
  "alloy-rlp",
  "derive_more",
@@ -9740,7 +9742,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#72647dffbe31cb3fcbb03a1e5a91fc6c6eac8d42"
 dependencies = [
  "auto_impl",
  "dyn-clone",
@@ -9758,10 +9760,10 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#72647dffbe31cb3fcbb03a1e5a91fc6c6eac8d42"
 dependencies = [
- "alloy-consensus 1.0.23",
- "alloy-eips 1.0.23",
+ "alloy-consensus 1.0.24",
+ "alloy-eips 1.0.24",
  "alloy-genesis",
  "alloy-primitives",
  "rand 0.8.5",
@@ -9774,7 +9776,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#72647dffbe31cb3fcbb03a1e5a91fc6c6eac8d42"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -9784,7 +9786,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#72647dffbe31cb3fcbb03a1e5a91fc6c6eac8d42"
 dependencies = [
  "clap",
  "eyre",
@@ -9799,10 +9801,10 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#72647dffbe31cb3fcbb03a1e5a91fc6c6eac8d42"
 dependencies = [
- "alloy-consensus 1.0.23",
- "alloy-eips 1.0.23",
+ "alloy-consensus 1.0.24",
+ "alloy-eips 1.0.24",
  "alloy-primitives",
  "alloy-rlp",
  "aquamarine",
@@ -9838,10 +9840,10 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#72647dffbe31cb3fcbb03a1e5a91fc6c6eac8d42"
 dependencies = [
- "alloy-consensus 1.0.23",
- "alloy-eips 1.0.23",
+ "alloy-consensus 1.0.24",
+ "alloy-eips 1.0.24",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-trie 0.9.0",
@@ -9863,13 +9865,13 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#72647dffbe31cb3fcbb03a1e5a91fc6c6eac8d42"
 dependencies = [
- "alloy-consensus 1.0.23",
+ "alloy-consensus 1.0.24",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-rpc-types-eth",
- "alloy-serde 1.0.23",
+ "alloy-serde 1.0.24",
  "alloy-trie 0.9.0",
  "arbitrary",
  "bytes",
@@ -9888,7 +9890,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#72647dffbe31cb3fcbb03a1e5a91fc6c6eac8d42"
 dependencies = [
  "alloy-primitives",
  "reth-db-api",
@@ -9901,7 +9903,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#72647dffbe31cb3fcbb03a1e5a91fc6c6eac8d42"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9926,7 +9928,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#72647dffbe31cb3fcbb03a1e5a91fc6c6eac8d42"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9944,7 +9946,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse-parallel"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#72647dffbe31cb3fcbb03a1e5a91fc6c6eac8d42"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9960,7 +9962,7 @@ dependencies = [
 [[package]]
 name = "reth-zstd-compressors"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#72647dffbe31cb3fcbb03a1e5a91fc6c6eac8d42"
 dependencies = [
  "zstd",
 ]
@@ -10039,7 +10041,7 @@ name = "revm-database"
 version = "7.0.2"
 source = "git+https://github.com/scroll-tech/revm#9cd9896c06a5bf6d4212906260d8789579873ba4"
 dependencies = [
- "alloy-eips 1.0.23",
+ "alloy-eips 1.0.24",
  "revm-bytecode",
  "revm-database-interface",
  "revm-primitives",
@@ -10316,11 +10318,11 @@ dependencies = [
 name = "rollup-node"
 version = "0.0.1"
 dependencies = [
- "alloy-eips 1.0.23",
+ "alloy-eips 1.0.24",
  "alloy-primitives",
  "alloy-provider",
  "alloy-rpc-client",
- "alloy-rpc-types-engine 1.0.23",
+ "alloy-rpc-types-engine 1.0.24",
  "alloy-signer",
  "alloy-signer-aws",
  "alloy-signer-local",
@@ -10415,11 +10417,11 @@ name = "rollup-node-manager"
 version = "0.0.1"
 dependencies = [
  "alloy-chains",
- "alloy-consensus 1.0.23",
- "alloy-eips 1.0.23",
+ "alloy-consensus 1.0.24",
+ "alloy-eips 1.0.24",
  "alloy-primitives",
  "alloy-provider",
- "alloy-rpc-types-engine 1.0.23",
+ "alloy-rpc-types-engine 1.0.24",
  "futures",
  "reth-chainspec",
  "reth-network",
@@ -10455,10 +10457,10 @@ name = "rollup-node-primitives"
 version = "0.0.1"
 dependencies = [
  "alloy-chains",
- "alloy-consensus 1.0.23",
- "alloy-eips 1.0.23",
+ "alloy-consensus 1.0.24",
+ "alloy-eips 1.0.24",
  "alloy-primitives",
- "alloy-rpc-types-engine 1.0.23",
+ "alloy-rpc-types-engine 1.0.24",
  "arbitrary",
  "derive_more",
  "reth-primitives-traits",
@@ -10471,7 +10473,7 @@ dependencies = [
 name = "rollup-node-providers"
 version = "0.0.1"
 dependencies = [
- "alloy-eips 1.0.23",
+ "alloy-eips 1.0.24",
  "alloy-primitives",
  "alloy-provider",
  "alloy-rpc-client",
@@ -10498,10 +10500,10 @@ dependencies = [
 name = "rollup-node-sequencer"
 version = "0.0.1"
 dependencies = [
- "alloy-consensus 1.0.23",
- "alloy-eips 1.0.23",
+ "alloy-consensus 1.0.24",
+ "alloy-eips 1.0.24",
  "alloy-primitives",
- "alloy-rpc-types-engine 1.0.23",
+ "alloy-rpc-types-engine 1.0.24",
  "alloy-signer-local",
  "eyre",
  "futures",
@@ -10552,8 +10554,8 @@ dependencies = [
 name = "rollup-node-watcher"
 version = "0.0.1"
 dependencies = [
- "alloy-consensus 1.0.23",
- "alloy-eips 1.0.23",
+ "alloy-consensus 1.0.24",
+ "alloy-eips 1.0.24",
  "alloy-json-rpc",
  "alloy-network",
  "alloy-primitives",
@@ -10950,13 +10952,13 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 [[package]]
 name = "scroll-alloy-consensus"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#72647dffbe31cb3fcbb03a1e5a91fc6c6eac8d42"
 dependencies = [
- "alloy-consensus 1.0.23",
- "alloy-eips 1.0.23",
+ "alloy-consensus 1.0.24",
+ "alloy-eips 1.0.24",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde 1.0.23",
+ "alloy-serde 1.0.24",
  "arbitrary",
  "derive_more",
  "modular-bitfield",
@@ -10969,10 +10971,10 @@ dependencies = [
 [[package]]
 name = "scroll-alloy-evm"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#72647dffbe31cb3fcbb03a1e5a91fc6c6eac8d42"
 dependencies = [
- "alloy-consensus 1.0.23",
- "alloy-eips 1.0.23",
+ "alloy-consensus 1.0.24",
+ "alloy-eips 1.0.24",
  "alloy-evm",
  "alloy-primitives",
  "auto_impl",
@@ -10987,7 +10989,7 @@ dependencies = [
 [[package]]
 name = "scroll-alloy-hardforks"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#72647dffbe31cb3fcbb03a1e5a91fc6c6eac8d42"
 dependencies = [
  "alloy-hardforks",
  "auto_impl",
@@ -10997,9 +10999,9 @@ dependencies = [
 [[package]]
 name = "scroll-alloy-network"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#72647dffbe31cb3fcbb03a1e5a91fc6c6eac8d42"
 dependencies = [
- "alloy-consensus 1.0.23",
+ "alloy-consensus 1.0.24",
  "alloy-network",
  "alloy-primitives",
  "alloy-provider",
@@ -11012,12 +11014,12 @@ dependencies = [
 [[package]]
 name = "scroll-alloy-provider"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#72647dffbe31cb3fcbb03a1e5a91fc6c6eac8d42"
 dependencies = [
  "alloy-primitives",
  "alloy-provider",
  "alloy-rpc-client",
- "alloy-rpc-types-engine 1.0.23",
+ "alloy-rpc-types-engine 1.0.24",
  "alloy-transport",
  "alloy-transport-http",
  "async-trait",
@@ -11037,14 +11039,14 @@ dependencies = [
 [[package]]
 name = "scroll-alloy-rpc-types"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#72647dffbe31cb3fcbb03a1e5a91fc6c6eac8d42"
 dependencies = [
- "alloy-consensus 1.0.23",
- "alloy-eips 1.0.23",
+ "alloy-consensus 1.0.24",
+ "alloy-eips 1.0.24",
  "alloy-network-primitives",
  "alloy-primitives",
  "alloy-rpc-types-eth",
- "alloy-serde 1.0.23",
+ "alloy-serde 1.0.24",
  "derive_more",
  "scroll-alloy-consensus",
  "serde",
@@ -11054,10 +11056,10 @@ dependencies = [
 [[package]]
 name = "scroll-alloy-rpc-types-engine"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#72647dffbe31cb3fcbb03a1e5a91fc6c6eac8d42"
 dependencies = [
  "alloy-primitives",
- "alloy-rpc-types-engine 1.0.23",
+ "alloy-rpc-types-engine 1.0.24",
  "arbitrary",
  "serde",
 ]
@@ -11066,7 +11068,7 @@ dependencies = [
 name = "scroll-codec"
 version = "0.1.0"
 dependencies = [
- "alloy-eips 1.0.23",
+ "alloy-eips 1.0.24",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-sol-types",
@@ -11083,7 +11085,7 @@ dependencies = [
 name = "scroll-db"
 version = "0.0.1"
 dependencies = [
- "alloy-eips 1.0.23",
+ "alloy-eips 1.0.24",
  "alloy-primitives",
  "arbitrary",
  "async-trait",
@@ -11104,9 +11106,9 @@ dependencies = [
 name = "scroll-derivation-pipeline"
 version = "0.0.1"
 dependencies = [
- "alloy-eips 1.0.23",
+ "alloy-eips 1.0.24",
  "alloy-primitives",
- "alloy-rpc-types-engine 1.0.23",
+ "alloy-rpc-types-engine 1.0.24",
  "async-trait",
  "criterion",
  "eyre",
@@ -11129,11 +11131,11 @@ name = "scroll-engine"
 version = "0.0.1"
 dependencies = [
  "alloy-chains",
- "alloy-consensus 1.0.23",
- "alloy-eips 1.0.23",
+ "alloy-consensus 1.0.24",
+ "alloy-eips 1.0.24",
  "alloy-primitives",
  "alloy-provider",
- "alloy-rpc-types-engine 1.0.23",
+ "alloy-rpc-types-engine 1.0.24",
  "arbitrary",
  "async-trait",
  "eyre",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1051,9 +1051,9 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstream"
-version = "0.6.19"
+version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "301af1932e46185686725e0fad2f8f2aa7da69dd70bf6ecc44d6b703844a3933"
+checksum = "3ae563653d1938f79b1ab1b5e668c87c76a9930414574a6583a7b7e11a8e6192"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -1081,22 +1081,22 @@ dependencies = [
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8bdeb6047d8983be085bab0ba1472e6dc604e7041dbf6fcd5e71523014fae9"
+checksum = "9e231f6134f61b71076a3eab506c379d4f36122f2af15a9ff04415ea4c3339e2"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.9"
+version = "3.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "403f75924867bb1033c59fbf0797484329750cfbe3c4325cd33127941fabc882"
+checksum = "3e0633414522a32ffaac8ac6cc8f748e090c5717661fddeea04219e2344f5f2a"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1543,9 +1543,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-config"
-version = "1.8.3"
+version = "1.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0baa720ebadea158c5bda642ac444a2af0cdf7bb66b46d1e4533de5d1f449d0"
+checksum = "483020b893cdef3d89637e428d588650c71cfae7ea2e6ecbaee4de4ff99fb2dd"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -1573,9 +1573,9 @@ dependencies = [
 
 [[package]]
 name = "aws-credential-types"
-version = "1.2.4"
+version = "1.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b68c2194a190e1efc999612792e25b1ab3abfefe4306494efaaabc25933c0cbe"
+checksum = "1541072f81945fa1251f8795ef6c92c4282d74d59f88498ae7d4bf00f0ebdad9"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
@@ -1608,9 +1608,9 @@ dependencies = [
 
 [[package]]
 name = "aws-runtime"
-version = "1.5.9"
+version = "1.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2090e664216c78e766b6bac10fe74d2f451c02441d43484cd76ac9a295075f7"
+checksum = "c034a1bc1d70e16e7f4e4caf7e9f7693e4c9c24cd91cf17c2a0b21abaebc7c8b"
 dependencies = [
  "aws-credential-types",
  "aws-sigv4",
@@ -1632,9 +1632,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-kms"
-version = "1.81.0"
+version = "1.82.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04729ca4652a5363689c07f825fea6649b1967820caafea5122a197e47ee83cb"
+checksum = "5296e1ff23bcb95f58a8250e2d00525daf23888ed2021c05bdfdbf79e1531784"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -1654,9 +1654,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sso"
-version = "1.78.0"
+version = "1.79.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbd7bc4bd34303733bded362c4c997a39130eac4310257c79aae8484b1c4b724"
+checksum = "0a847168f15b46329fa32c7aca4e4f1a2e072f9b422f0adb19756f2e1457f111"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -1676,9 +1676,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ssooidc"
-version = "1.79.0"
+version = "1.80.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77358d25f781bb106c1a69531231d4fd12c6be904edb0c47198c604df5a2dbca"
+checksum = "b654dd24d65568738593e8239aef279a86a15374ec926ae8714e2d7245f34149"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -1698,9 +1698,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sts"
-version = "1.80.0"
+version = "1.81.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06e3ed2a9b828ae7763ddaed41d51724d2661a50c45f845b08967e52f4939cfc"
+checksum = "c92ea8a7602321c83615c82b408820ad54280fb026e92de0eeea937342fafa24"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -1721,9 +1721,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sigv4"
-version = "1.3.3"
+version = "1.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddfb9021f581b71870a17eac25b52335b82211cdc092e02b6876b2bcefa61666"
+checksum = "084c34162187d39e3740cb635acd73c4e3a551a36146ad6fe8883c929c9f876c"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-http",
@@ -1754,9 +1754,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http"
-version = "0.62.2"
+version = "0.62.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43c82ba4cab184ea61f6edaafc1072aad3c2a17dcf4c0fce19ac5694b90d8b5f"
+checksum = "7c4dacf2d38996cf729f55e7a762b30918229917eca115de45dfa8dfb97796c9"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -1782,7 +1782,7 @@ dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "h2 0.3.27",
- "h2 0.4.11",
+ "h2 0.4.12",
  "http 0.2.12",
  "http 1.3.1",
  "http-body 0.4.6",
@@ -1831,9 +1831,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "1.8.5"
+version = "1.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "660f70d9d8af6876b4c9aa8dcb0dbaf0f89b04ee9a4455bea1b4ba03b15f26f6"
+checksum = "9e107ce0783019dbff59b3a244aa0c114e4a8c9d93498af9162608cd5474e796"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-http",
@@ -1855,9 +1855,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime-api"
-version = "1.8.5"
+version = "1.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "937a49ecf061895fca4a6dd8e864208ed9be7546c0527d04bc07d502ec5fba1c"
+checksum = "75d52251ed4b9776a3e8487b2a01ac915f73b2da3af8fc1e77e0fce697a550d4"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-types",
@@ -2496,9 +2496,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.42"
+version = "4.5.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed87a9d530bb41a67537289bafcac159cb3ee28460e0a4571123d2a778a6a882"
+checksum = "50fd97c9dc2399518aa331917ac6f274280ec5eb34e555dd291899745c48ec6f"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -2506,9 +2506,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.42"
+version = "4.5.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64f4f3f3c77c94aff3c7e9aac9a2ca1974a5adf392a8bb751e827d6d127ab966"
+checksum = "c35b5830294e1fa0462034af85cc95225a4cb07092c088c55bda3147cfcd8f65"
 dependencies = [
  "anstream",
  "anstyle",
@@ -3100,9 +3100,9 @@ dependencies = [
 
 [[package]]
 name = "derive-where"
-version = "1.5.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "510c292c8cf384b1a340b816a9a6cf2599eb8f566a44949024af88418000c50b"
+checksum = "ef941ded77d15ca19b40374869ac6000af1c9f2a4c0f3d4c70926287e6364a8f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3227,7 +3227,7 @@ checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
 dependencies = [
  "libc",
  "option-ext",
- "redox_users 0.5.1",
+ "redox_users 0.5.2",
  "windows-sys 0.60.2",
 ]
 
@@ -3398,6 +3398,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
+name = "encoder-standard"
+version = "0.1.0"
+source = "git+https://github.com/scroll-tech/da-codec#2cfec8c99547b68dc64e2b020fa2b83cfb9c0e99"
+dependencies = [
+ "zstd",
+]
+
+[[package]]
 name = "encoding_rs"
 version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3558,9 +3566,9 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "5.4.0"
+version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3492acde4c3fc54c845eaab3eed8bd00c7a7d881f78bfc801e43a93dec1331ae"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
 dependencies = [
  "concurrent-queue",
  "parking",
@@ -4025,9 +4033,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17da50a276f1e01e0ba6c029e47b7100754904ee8a278f886546e98575380785"
+checksum = "f3c0b69cfcb4e1b9f1bf2f53f95f766e4661169728ec61cd3fe5a0166f2d1386"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -4362,7 +4370,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "h2 0.4.11",
+ "h2 0.4.12",
  "http 1.3.1",
  "http-body 1.0.1",
  "httparse",
@@ -4639,9 +4647,9 @@ dependencies = [
 
 [[package]]
 name = "indenter"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
+checksum = "964de6e86d545b246d84badc0fef527924ace5134f30641c203ef52ba83f58d5"
 
 [[package]]
 name = "indexmap"
@@ -5703,9 +5711,9 @@ dependencies = [
 
 [[package]]
 name = "notify"
-version = "8.1.0"
+version = "8.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3163f59cd3fa0e9ef8c32f242966a7b9994fd7378366099593e0e73077cd8c97"
+checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
 dependencies = [
  "bitflags 2.9.1",
  "fsevent-sys",
@@ -5947,9 +5955,9 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "op-alloy-consensus"
-version = "0.18.13"
+version = "0.18.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3c719b26da6d9cac18c3a35634d6ab27a74a304ed9b403b43749c22e57a389f"
+checksum = "0c88d2940558fd69f8f07b3cbd7bb3c02fc7d31159c1a7ba9deede50e7881024"
 dependencies = [
  "alloy-consensus 1.0.23",
  "alloy-eips 1.0.23",
@@ -5965,9 +5973,9 @@ dependencies = [
 
 [[package]]
 name = "op-alloy-rpc-types-engine"
-version = "0.18.13"
+version = "0.18.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cf45d43a3d548fdc39d9bfab6ba13cc06b3214ef4b9c36d3efbf3faea1b9f1"
+checksum = "b2b4f977b51e9e177e69a4d241ab7c4b439df9a3a5a998c000ae01be724de271"
 dependencies = [
  "alloy-consensus 1.0.23",
  "alloy-eips 1.0.23",
@@ -6917,9 +6925,9 @@ dependencies = [
 
 [[package]]
 name = "redox_users"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78eaea1f52c56d57821be178b2d47e09ff26481a6042e8e042fcb0ced068b470"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
  "getrandom 0.2.16",
  "libredox",
@@ -7017,7 +7025,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.4.11",
+ "h2 0.4.12",
  "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
@@ -7100,7 +7108,7 @@ checksum = "95325155c684b1c89f7765e30bc1c42e4a6da51ca513615660cb8a62ef9a88e3"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git#f451fe852900aa68b6f9d8df1a838da5adf23401"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
 dependencies = [
  "alloy-consensus 1.0.23",
  "alloy-eips 1.0.23",
@@ -7124,7 +7132,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git#f451fe852900aa68b6f9d8df1a838da5adf23401"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
 dependencies = [
  "alloy-consensus 1.0.23",
  "alloy-eips 1.0.23",
@@ -7155,7 +7163,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git#f451fe852900aa68b6f9d8df1a838da5adf23401"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
 dependencies = [
  "alloy-chains",
  "alloy-consensus 1.0.23",
@@ -7175,7 +7183,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git#f451fe852900aa68b6f9d8df1a838da5adf23401"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -7189,7 +7197,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git#f451fe852900aa68b6f9d8df1a838da5adf23401"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
 dependencies = [
  "ahash 0.8.12",
  "alloy-chains",
@@ -7262,7 +7270,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git#f451fe852900aa68b6f9d8df1a838da5adf23401"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -7272,7 +7280,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git#f451fe852900aa68b6f9d8df1a838da5adf23401"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
 dependencies = [
  "alloy-eips 1.0.23",
  "alloy-primitives",
@@ -7289,7 +7297,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git#f451fe852900aa68b6f9d8df1a838da5adf23401"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
 dependencies = [
  "alloy-consensus 1.0.23",
  "alloy-eips 1.0.23",
@@ -7309,7 +7317,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs-derive"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git#f451fe852900aa68b6f9d8df1a838da5adf23401"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
 dependencies = [
  "convert_case",
  "proc-macro2",
@@ -7320,7 +7328,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git#f451fe852900aa68b6f9d8df1a838da5adf23401"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -7335,7 +7343,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git#f451fe852900aa68b6f9d8df1a838da5adf23401"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
 dependencies = [
  "alloy-consensus 1.0.23",
  "alloy-primitives",
@@ -7348,7 +7356,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git#f451fe852900aa68b6f9d8df1a838da5adf23401"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
 dependencies = [
  "alloy-consensus 1.0.23",
  "alloy-eips 1.0.23",
@@ -7360,7 +7368,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git#f451fe852900aa68b6f9d8df1a838da5adf23401"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
 dependencies = [
  "alloy-consensus 1.0.23",
  "alloy-eips 1.0.23",
@@ -7385,7 +7393,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git#f451fe852900aa68b6f9d8df1a838da5adf23401"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -7411,7 +7419,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git#f451fe852900aa68b6f9d8df1a838da5adf23401"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
 dependencies = [
  "alloy-consensus 1.0.23",
  "alloy-genesis",
@@ -7440,7 +7448,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git#f451fe852900aa68b6f9d8df1a838da5adf23401"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
 dependencies = [
  "alloy-consensus 1.0.23",
  "alloy-genesis",
@@ -7469,7 +7477,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git#f451fe852900aa68b6f9d8df1a838da5adf23401"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
 dependencies = [
  "alloy-eips 1.0.23",
  "alloy-primitives",
@@ -7484,7 +7492,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git#f451fe852900aa68b6f9d8df1a838da5adf23401"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -7510,7 +7518,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git#f451fe852900aa68b6f9d8df1a838da5adf23401"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -7534,7 +7542,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git#f451fe852900aa68b6f9d8df1a838da5adf23401"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
 dependencies = [
  "alloy-primitives",
  "data-encoding",
@@ -7558,7 +7566,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git#f451fe852900aa68b6f9d8df1a838da5adf23401"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
 dependencies = [
  "alloy-consensus 1.0.23",
  "alloy-eips 1.0.23",
@@ -7593,7 +7601,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git#f451fe852900aa68b6f9d8df1a838da5adf23401"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
 dependencies = [
  "alloy-consensus 1.0.23",
  "alloy-eips 1.0.23",
@@ -7655,7 +7663,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git#f451fe852900aa68b6f9d8df1a838da5adf23401"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -7686,7 +7694,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git#f451fe852900aa68b6f9d8df1a838da5adf23401"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
 dependencies = [
  "alloy-consensus 1.0.23",
  "alloy-primitives",
@@ -7709,7 +7717,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git#f451fe852900aa68b6f9d8df1a838da5adf23401"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
 dependencies = [
  "alloy-consensus 1.0.23",
  "alloy-eips 1.0.23",
@@ -7734,7 +7742,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-service"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git#f451fe852900aa68b6f9d8df1a838da5adf23401"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
 dependencies = [
  "futures",
  "pin-project",
@@ -7757,7 +7765,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git#f451fe852900aa68b6f9d8df1a838da5adf23401"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
 dependencies = [
  "alloy-consensus 1.0.23",
  "alloy-eips 1.0.23",
@@ -7810,7 +7818,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git#f451fe852900aa68b6f9d8df1a838da5adf23401"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
 dependencies = [
  "alloy-consensus 1.0.23",
  "alloy-rpc-types-engine 1.0.23",
@@ -7837,7 +7845,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git#f451fe852900aa68b6f9d8df1a838da5adf23401"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
 dependencies = [
  "alloy-consensus 1.0.23",
  "alloy-eips 1.0.23",
@@ -7853,7 +7861,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git#f451fe852900aa68b6f9d8df1a838da5adf23401"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -7868,7 +7876,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git#f451fe852900aa68b6f9d8df1a838da5adf23401"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
 dependencies = [
  "alloy-consensus 1.0.23",
  "alloy-primitives",
@@ -7892,7 +7900,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git#f451fe852900aa68b6f9d8df1a838da5adf23401"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -7903,7 +7911,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git#f451fe852900aa68b6f9d8df1a838da5adf23401"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -7931,7 +7939,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git#f451fe852900aa68b6f9d8df1a838da5adf23401"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
 dependencies = [
  "alloy-chains",
  "alloy-consensus 1.0.23",
@@ -7952,7 +7960,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git#f451fe852900aa68b6f9d8df1a838da5adf23401"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
 dependencies = [
  "alloy-consensus 1.0.23",
  "alloy-eips 1.0.23",
@@ -7968,7 +7976,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git#f451fe852900aa68b6f9d8df1a838da5adf23401"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
 dependencies = [
  "alloy-eips 1.0.23",
  "alloy-primitives",
@@ -7986,7 +7994,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git#f451fe852900aa68b6f9d8df1a838da5adf23401"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -8000,7 +8008,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git#f451fe852900aa68b6f9d8df1a838da5adf23401"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
 dependencies = [
  "alloy-consensus 1.0.23",
  "alloy-eips 1.0.23",
@@ -8027,7 +8035,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git#f451fe852900aa68b6f9d8df1a838da5adf23401"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
 dependencies = [
  "alloy-consensus 1.0.23",
  "alloy-eips 1.0.23",
@@ -8045,7 +8053,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git#f451fe852900aa68b6f9d8df1a838da5adf23401"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -8055,7 +8063,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git#f451fe852900aa68b6f9d8df1a838da5adf23401"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
 dependencies = [
  "alloy-consensus 1.0.23",
  "alloy-eips 1.0.23",
@@ -8079,7 +8087,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git#f451fe852900aa68b6f9d8df1a838da5adf23401"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
 dependencies = [
  "alloy-consensus 1.0.23",
  "alloy-eips 1.0.23",
@@ -8097,7 +8105,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git#f451fe852900aa68b6f9d8df1a838da5adf23401"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -8110,7 +8118,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git#f451fe852900aa68b6f9d8df1a838da5adf23401"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
 dependencies = [
  "alloy-consensus 1.0.23",
  "alloy-eips 1.0.23",
@@ -8128,7 +8136,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git#f451fe852900aa68b6f9d8df1a838da5adf23401"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
 dependencies = [
  "alloy-consensus 1.0.23",
  "alloy-eips 1.0.23",
@@ -8166,7 +8174,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git#f451fe852900aa68b6f9d8df1a838da5adf23401"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
 dependencies = [
  "alloy-eips 1.0.23",
  "alloy-primitives",
@@ -8180,7 +8188,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git#f451fe852900aa68b6f9d8df1a838da5adf23401"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
 dependencies = [
  "serde",
  "serde_json",
@@ -8190,7 +8198,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git#f451fe852900aa68b6f9d8df1a838da5adf23401"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
 dependencies = [
  "alloy-consensus 1.0.23",
  "alloy-primitives",
@@ -8218,7 +8226,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git#f451fe852900aa68b6f9d8df1a838da5adf23401"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
 dependencies = [
  "bytes",
  "futures",
@@ -8238,7 +8246,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git#f451fe852900aa68b6f9d8df1a838da5adf23401"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
 dependencies = [
  "bitflags 2.9.1",
  "byteorder",
@@ -8255,7 +8263,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git#f451fe852900aa68b6f9d8df1a838da5adf23401"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
 dependencies = [
  "bindgen 0.70.1",
  "cc",
@@ -8264,7 +8272,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git#f451fe852900aa68b6f9d8df1a838da5adf23401"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
 dependencies = [
  "futures",
  "metrics",
@@ -8276,7 +8284,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git#f451fe852900aa68b6f9d8df1a838da5adf23401"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
 dependencies = [
  "alloy-primitives",
 ]
@@ -8284,7 +8292,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git#f451fe852900aa68b6f9d8df1a838da5adf23401"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -8298,7 +8306,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git#f451fe852900aa68b6f9d8df1a838da5adf23401"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
 dependencies = [
  "alloy-consensus 1.0.23",
  "alloy-eips 1.0.23",
@@ -8353,7 +8361,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git#f451fe852900aa68b6f9d8df1a838da5adf23401"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
 dependencies = [
  "alloy-consensus 1.0.23",
  "alloy-primitives",
@@ -8379,7 +8387,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git#f451fe852900aa68b6f9d8df1a838da5adf23401"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
 dependencies = [
  "alloy-consensus 1.0.23",
  "alloy-eips 1.0.23",
@@ -8402,7 +8410,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git#f451fe852900aa68b6f9d8df1a838da5adf23401"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8417,7 +8425,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git#f451fe852900aa68b6f9d8df1a838da5adf23401"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -8431,7 +8439,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git#f451fe852900aa68b6f9d8df1a838da5adf23401"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
 dependencies = [
  "anyhow",
  "bincode",
@@ -8448,7 +8456,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git#f451fe852900aa68b6f9d8df1a838da5adf23401"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
 dependencies = [
  "alloy-rpc-types-engine 1.0.23",
  "eyre",
@@ -8472,7 +8480,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git#f451fe852900aa68b6f9d8df1a838da5adf23401"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
 dependencies = [
  "alloy-consensus 1.0.23",
  "alloy-eips 1.0.23",
@@ -8538,7 +8546,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git#f451fe852900aa68b6f9d8df1a838da5adf23401"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
 dependencies = [
  "alloy-consensus 1.0.23",
  "alloy-eips 1.0.23",
@@ -8590,7 +8598,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git#f451fe852900aa68b6f9d8df1a838da5adf23401"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
 dependencies = [
  "alloy-eips 1.0.23",
  "alloy-network",
@@ -8628,7 +8636,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git#f451fe852900aa68b6f9d8df1a838da5adf23401"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
 dependencies = [
  "alloy-consensus 1.0.23",
  "alloy-primitives",
@@ -8652,7 +8660,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git#f451fe852900aa68b6f9d8df1a838da5adf23401"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
 dependencies = [
  "alloy-consensus 1.0.23",
  "alloy-eips 1.0.23",
@@ -8676,7 +8684,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git#f451fe852900aa68b6f9d8df1a838da5adf23401"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
 dependencies = [
  "eyre",
  "http 1.3.1",
@@ -8696,7 +8704,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git#f451fe852900aa68b6f9d8df1a838da5adf23401"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -8709,7 +8717,7 @@ dependencies = [
 [[package]]
 name = "reth-optimism-primitives"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git#f451fe852900aa68b6f9d8df1a838da5adf23401"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
 dependencies = [
  "alloy-consensus 1.0.23",
  "alloy-eips 1.0.23",
@@ -8728,7 +8736,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git#f451fe852900aa68b6f9d8df1a838da5adf23401"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
 dependencies = [
  "alloy-consensus 1.0.23",
  "alloy-primitives",
@@ -8749,7 +8757,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git#f451fe852900aa68b6f9d8df1a838da5adf23401"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -8761,7 +8769,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git#f451fe852900aa68b6f9d8df1a838da5adf23401"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
 dependencies = [
  "alloy-eips 1.0.23",
  "alloy-primitives",
@@ -8781,7 +8789,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-util"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git#f451fe852900aa68b6f9d8df1a838da5adf23401"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
 dependencies = [
  "alloy-consensus 1.0.23",
  "alloy-primitives",
@@ -8791,7 +8799,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git#f451fe852900aa68b6f9d8df1a838da5adf23401"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
 dependencies = [
  "alloy-consensus 1.0.23",
  "alloy-rpc-types-engine 1.0.23",
@@ -8801,7 +8809,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git#f451fe852900aa68b6f9d8df1a838da5adf23401"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
 dependencies = [
  "alloy-consensus 1.0.23",
  "arbitrary",
@@ -8816,7 +8824,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives-traits"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git#f451fe852900aa68b6f9d8df1a838da5adf23401"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
 dependencies = [
  "alloy-consensus 1.0.23",
  "alloy-eips 1.0.23",
@@ -8850,7 +8858,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git#f451fe852900aa68b6f9d8df1a838da5adf23401"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
 dependencies = [
  "alloy-consensus 1.0.23",
  "alloy-eips 1.0.23",
@@ -8895,7 +8903,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git#f451fe852900aa68b6f9d8df1a838da5adf23401"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
 dependencies = [
  "alloy-consensus 1.0.23",
  "alloy-eips 1.0.23",
@@ -8923,7 +8931,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git#f451fe852900aa68b6f9d8df1a838da5adf23401"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -8937,7 +8945,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git#f451fe852900aa68b6f9d8df1a838da5adf23401"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
 dependencies = [
  "alloy-primitives",
  "reth-primitives-traits",
@@ -8950,7 +8958,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git#f451fe852900aa68b6f9d8df1a838da5adf23401"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
 dependencies = [
  "alloy-consensus 1.0.23",
  "alloy-dyn-abi",
@@ -9026,7 +9034,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git#f451fe852900aa68b6f9d8df1a838da5adf23401"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
 dependencies = [
  "alloy-eips 1.0.23",
  "alloy-genesis",
@@ -9054,7 +9062,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git#f451fe852900aa68b6f9d8df1a838da5adf23401"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -9092,7 +9100,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git#f451fe852900aa68b6f9d8df1a838da5adf23401"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
 dependencies = [
  "alloy-consensus 1.0.23",
  "alloy-json-rpc",
@@ -9117,7 +9125,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git#f451fe852900aa68b6f9d8df1a838da5adf23401"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
 dependencies = [
  "alloy-eips 1.0.23",
  "alloy-primitives",
@@ -9147,7 +9155,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git#f451fe852900aa68b6f9d8df1a838da5adf23401"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
 dependencies = [
  "alloy-consensus 1.0.23",
  "alloy-dyn-abi",
@@ -9192,7 +9200,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git#f451fe852900aa68b6f9d8df1a838da5adf23401"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
 dependencies = [
  "alloy-consensus 1.0.23",
  "alloy-eips 1.0.23",
@@ -9236,7 +9244,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git#f451fe852900aa68b6f9d8df1a838da5adf23401"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
 dependencies = [
  "alloy-rpc-types-engine 1.0.23",
  "http 1.3.1",
@@ -9250,7 +9258,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git#f451fe852900aa68b6f9d8df1a838da5adf23401"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
 dependencies = [
  "alloy-eips 1.0.23",
  "alloy-primitives",
@@ -9266,7 +9274,7 @@ dependencies = [
 [[package]]
 name = "reth-scroll-chainspec"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git#f451fe852900aa68b6f9d8df1a838da5adf23401"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
 dependencies = [
  "alloy-chains",
  "alloy-consensus 1.0.23",
@@ -9291,7 +9299,7 @@ dependencies = [
 [[package]]
 name = "reth-scroll-cli"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git#f451fe852900aa68b6f9d8df1a838da5adf23401"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
 dependencies = [
  "clap",
  "eyre",
@@ -9315,7 +9323,7 @@ dependencies = [
 [[package]]
 name = "reth-scroll-consensus"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git#f451fe852900aa68b6f9d8df1a838da5adf23401"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
 dependencies = [
  "alloy-consensus 1.0.23",
  "alloy-primitives",
@@ -9334,7 +9342,7 @@ dependencies = [
 [[package]]
 name = "reth-scroll-engine-primitives"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git#f451fe852900aa68b6f9d8df1a838da5adf23401"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
 dependencies = [
  "alloy-consensus 1.0.23",
  "alloy-eips 1.0.23",
@@ -9359,7 +9367,7 @@ dependencies = [
 [[package]]
 name = "reth-scroll-evm"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git#f451fe852900aa68b6f9d8df1a838da5adf23401"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
 dependencies = [
  "alloy-consensus 1.0.23",
  "alloy-eips 1.0.23",
@@ -9388,7 +9396,7 @@ dependencies = [
 [[package]]
 name = "reth-scroll-forks"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git#f451fe852900aa68b6f9d8df1a838da5adf23401"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9402,7 +9410,7 @@ dependencies = [
 [[package]]
 name = "reth-scroll-node"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git#f451fe852900aa68b6f9d8df1a838da5adf23401"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
 dependencies = [
  "alloy-consensus 1.0.23",
  "alloy-genesis",
@@ -9454,7 +9462,7 @@ dependencies = [
 [[package]]
 name = "reth-scroll-payload"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git#f451fe852900aa68b6f9d8df1a838da5adf23401"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
 dependencies = [
  "alloy-consensus 1.0.23",
  "alloy-primitives",
@@ -9485,7 +9493,7 @@ dependencies = [
 [[package]]
 name = "reth-scroll-primitives"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git#f451fe852900aa68b6f9d8df1a838da5adf23401"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
 dependencies = [
  "alloy-consensus 1.0.23",
  "alloy-eips 1.0.23",
@@ -9505,7 +9513,7 @@ dependencies = [
 [[package]]
 name = "reth-scroll-rpc"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git#f451fe852900aa68b6f9d8df1a838da5adf23401"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
 dependencies = [
  "alloy-consensus 1.0.23",
  "alloy-eips 1.0.23",
@@ -9546,7 +9554,7 @@ dependencies = [
 [[package]]
 name = "reth-scroll-txpool"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git#f451fe852900aa68b6f9d8df1a838da5adf23401"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
 dependencies = [
  "alloy-consensus 1.0.23",
  "alloy-eips 1.0.23",
@@ -9569,7 +9577,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git#f451fe852900aa68b6f9d8df1a838da5adf23401"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
 dependencies = [
  "alloy-consensus 1.0.23",
  "alloy-eips 1.0.23",
@@ -9619,7 +9627,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git#f451fe852900aa68b6f9d8df1a838da5adf23401"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
 dependencies = [
  "alloy-eips 1.0.23",
  "alloy-primitives",
@@ -9646,7 +9654,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git#f451fe852900aa68b6f9d8df1a838da5adf23401"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -9660,7 +9668,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git#f451fe852900aa68b6f9d8df1a838da5adf23401"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
 dependencies = [
  "alloy-primitives",
  "parking_lot 0.12.4",
@@ -9680,7 +9688,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git#f451fe852900aa68b6f9d8df1a838da5adf23401"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -9692,7 +9700,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git#f451fe852900aa68b6f9d8df1a838da5adf23401"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
 dependencies = [
  "alloy-consensus 1.0.23",
  "alloy-eips 1.0.23",
@@ -9716,7 +9724,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git#f451fe852900aa68b6f9d8df1a838da5adf23401"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
 dependencies = [
  "alloy-eips 1.0.23",
  "alloy-primitives",
@@ -9732,7 +9740,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git#f451fe852900aa68b6f9d8df1a838da5adf23401"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
 dependencies = [
  "auto_impl",
  "dyn-clone",
@@ -9750,7 +9758,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git#f451fe852900aa68b6f9d8df1a838da5adf23401"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
 dependencies = [
  "alloy-consensus 1.0.23",
  "alloy-eips 1.0.23",
@@ -9766,7 +9774,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git#f451fe852900aa68b6f9d8df1a838da5adf23401"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -9776,7 +9784,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git#f451fe852900aa68b6f9d8df1a838da5adf23401"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
 dependencies = [
  "clap",
  "eyre",
@@ -9791,7 +9799,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git#f451fe852900aa68b6f9d8df1a838da5adf23401"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
 dependencies = [
  "alloy-consensus 1.0.23",
  "alloy-eips 1.0.23",
@@ -9830,7 +9838,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git#f451fe852900aa68b6f9d8df1a838da5adf23401"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
 dependencies = [
  "alloy-consensus 1.0.23",
  "alloy-eips 1.0.23",
@@ -9855,7 +9863,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git#f451fe852900aa68b6f9d8df1a838da5adf23401"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
 dependencies = [
  "alloy-consensus 1.0.23",
  "alloy-primitives",
@@ -9880,7 +9888,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git#f451fe852900aa68b6f9d8df1a838da5adf23401"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
 dependencies = [
  "alloy-primitives",
  "reth-db-api",
@@ -9893,7 +9901,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git#f451fe852900aa68b6f9d8df1a838da5adf23401"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9918,7 +9926,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git#f451fe852900aa68b6f9d8df1a838da5adf23401"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9936,7 +9944,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse-parallel"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git#f451fe852900aa68b6f9d8df1a838da5adf23401"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9952,7 +9960,7 @@ dependencies = [
 [[package]]
 name = "reth-zstd-compressors"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git#f451fe852900aa68b6f9d8df1a838da5adf23401"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
 dependencies = [
  "zstd",
 ]
@@ -10611,9 +10619,9 @@ dependencies = [
 
 [[package]]
 name = "ruint"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11256b5fe8c68f56ac6f39ef0720e592f33d2367a4782740d9c9142e889c7fb4"
+checksum = "9ecb38f82477f20c5c3d62ef52d7c4e536e38ea9b73fb570a20c5cae0e14bcf6"
 dependencies = [
  "alloy-rlp",
  "arbitrary",
@@ -10779,7 +10787,7 @@ dependencies = [
  "openssl-probe",
  "rustls-pki-types",
  "schannel",
- "security-framework 3.2.0",
+ "security-framework 3.3.0",
 ]
 
 [[package]]
@@ -10816,7 +10824,7 @@ dependencies = [
  "rustls-native-certs 0.8.1",
  "rustls-platform-verifier-android",
  "rustls-webpki 0.103.4",
- "security-framework 3.2.0",
+ "security-framework 3.3.0",
  "security-framework-sys",
  "webpki-root-certs 0.26.11",
  "windows-sys 0.59.0",
@@ -10942,7 +10950,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 [[package]]
 name = "scroll-alloy-consensus"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git#f451fe852900aa68b6f9d8df1a838da5adf23401"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
 dependencies = [
  "alloy-consensus 1.0.23",
  "alloy-eips 1.0.23",
@@ -10961,25 +10969,25 @@ dependencies = [
 [[package]]
 name = "scroll-alloy-evm"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git#f451fe852900aa68b6f9d8df1a838da5adf23401"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
 dependencies = [
  "alloy-consensus 1.0.23",
  "alloy-eips 1.0.23",
  "alloy-evm",
  "alloy-primitives",
  "auto_impl",
+ "encoder-standard",
  "revm",
  "revm-scroll",
  "scroll-alloy-consensus",
  "scroll-alloy-hardforks",
  "serde",
- "zstd",
 ]
 
 [[package]]
 name = "scroll-alloy-hardforks"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git#f451fe852900aa68b6f9d8df1a838da5adf23401"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
 dependencies = [
  "alloy-hardforks",
  "auto_impl",
@@ -10989,7 +10997,7 @@ dependencies = [
 [[package]]
 name = "scroll-alloy-network"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git#f451fe852900aa68b6f9d8df1a838da5adf23401"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
 dependencies = [
  "alloy-consensus 1.0.23",
  "alloy-network",
@@ -11004,7 +11012,7 @@ dependencies = [
 [[package]]
 name = "scroll-alloy-provider"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git#f451fe852900aa68b6f9d8df1a838da5adf23401"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
 dependencies = [
  "alloy-primitives",
  "alloy-provider",
@@ -11029,7 +11037,7 @@ dependencies = [
 [[package]]
 name = "scroll-alloy-rpc-types"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git#f451fe852900aa68b6f9d8df1a838da5adf23401"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
 dependencies = [
  "alloy-consensus 1.0.23",
  "alloy-eips 1.0.23",
@@ -11046,7 +11054,7 @@ dependencies = [
 [[package]]
 name = "scroll-alloy-rpc-types-engine"
 version = "1.6.0"
-source = "git+https://github.com/scroll-tech/reth.git#f451fe852900aa68b6f9d8df1a838da5adf23401"
+source = "git+https://github.com/scroll-tech/reth.git?branch=feat-forward-sequencer-no-blocking#fdf1379f7ec43282d6760bfcc3a22743f4386e01"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-engine 1.0.23",
@@ -11325,9 +11333,9 @@ dependencies = [
 
 [[package]]
 name = "sea-query"
-version = "0.32.6"
+version = "0.32.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64c91783d1514b99754fc6a4079081dcc2c587dadbff65c48c7f62297443536a"
+checksum = "8a5d1c518eaf5eda38e5773f902b26ab6d5e9e9e2bb2349ca6c64cf96f80448c"
 dependencies = [
  "bigdecimal",
  "chrono",
@@ -11472,9 +11480,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "3.2.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271720403f46ca04f7ba6f55d438f8bd878d6b8ca0a1046e8228c4145bcbb316"
+checksum = "80fb1d92c5028aa318b4b8bd7302a5bfcf48be96a37fc6fc790f806b0004ee0c"
 dependencies = [
  "bitflags 2.9.1",
  "core-foundation 0.10.1",
@@ -11554,9 +11562,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.141"
+version = "1.0.142"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30b9eff21ebe718216c6ec64e1d9ac57087aad11efc64e32002bce4a0d4c03d3"
+checksum = "030fedb782600dcbd6f02d479bf0d817ac3bb40d644745b769d6a96bc3afc5a7"
 dependencies = [
  "indexmap 2.10.0",
  "itoa",
@@ -11730,9 +11738,9 @@ dependencies = [
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.5"
+version = "1.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9203b8055f63a2a00e2f593bb0510367fe707d7ff1e5c872de2f537b339e5410"
+checksum = "b2a4719bff48cee6b39d12c020eeb490953ad2443b7055bd0b21fca26bd8c28b"
 dependencies = [
  "libc",
 ]
@@ -12431,9 +12439,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.47.0"
+version = "1.47.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43864ed400b6043a4757a25c7a64a8efde741aed79a056a2fb348a406701bb35"
+checksum = "89e49afdadebb872d3145a5638b59eb0691ea23e46ca484037cfab3b76b95038"
 dependencies = [
  "backtrace",
  "bytes",
@@ -12521,9 +12529,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.15"
+version = "0.7.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66a539a9ad6d5d281510d5bd368c973d636c02dbf8a67300bfb6b950696ad7df"
+checksum = "14307c986784f72ef81c89db7d9e28d6ac26d16213b109ea501696195e6e3ce5"
 dependencies = [
  "bytes",
  "futures-core",
@@ -14075,9 +14083,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.2"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a05eb080e015ba39cc9e23bbe5e7fb04d5fb040350f99f34e338d5fdd294428"
+checksum = "e7aa2bd55086f1ab526693ecbe444205da57e25f4489879da80635a46d90e73b"
 dependencies = [
  "yoke",
  "zerofrom",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -134,37 +134,37 @@ alloy-signer-local = { version = "1.0.13", default-features = false }
 alloy-transport = { version = "1.0.13", default-features = false }
 
 # scroll-alloy
-scroll-alloy-consensus = { git = "https://github.com/scroll-tech/reth.git", default-features = false }
-scroll-alloy-hardforks = { git = "https://github.com/scroll-tech/reth.git", default-features = false }
-scroll-alloy-network = { git = "https://github.com/scroll-tech/reth.git", default-features = false }
-scroll-alloy-provider = { git = "https://github.com/scroll-tech/reth.git", default-features = false }
-scroll-alloy-rpc-types-engine = { git = "https://github.com/scroll-tech/reth.git", default-features = false }
+scroll-alloy-consensus = { git = "https://github.com/scroll-tech/reth.git", branch = "feat-forward-sequencer-no-blocking", default-features = false }
+scroll-alloy-hardforks = { git = "https://github.com/scroll-tech/reth.git", branch = "feat-forward-sequencer-no-blocking", default-features = false }
+scroll-alloy-network = { git = "https://github.com/scroll-tech/reth.git", branch = "feat-forward-sequencer-no-blocking", default-features = false }
+scroll-alloy-provider = { git = "https://github.com/scroll-tech/reth.git", branch = "feat-forward-sequencer-no-blocking", default-features = false }
+scroll-alloy-rpc-types-engine = { git = "https://github.com/scroll-tech/reth.git", branch = "feat-forward-sequencer-no-blocking", default-features = false }
 
 # reth
-reth-chainspec = { git = "https://github.com/scroll-tech/reth.git", default-features = false }
-reth-e2e-test-utils = { git = "https://github.com/scroll-tech/reth.git" }
-reth-eth-wire-types = { git = "https://github.com/scroll-tech/reth.git", default-features = false }
-reth-network = { git = "https://github.com/scroll-tech/reth.git", default-features = false }
-reth-network-api = { git = "https://github.com/scroll-tech/reth.git", default-features = false }
-reth-network-peers = { git = "https://github.com/scroll-tech/reth.git", default-features = false }
-reth-node-builder = { git = "https://github.com/scroll-tech/reth.git", default-features = false }
-reth-node-core = { git = "https://github.com/scroll-tech/reth.git", default-features = false }
-reth-payload-primitives = { git = "https://github.com/scroll-tech/reth.git", default-features = false }
-reth-primitives = { git = "https://github.com/scroll-tech/reth.git", default-features = false }
-reth-primitives-traits = { git = "https://github.com/scroll-tech/reth.git", default-features = false }
-reth-provider = { git = "https://github.com/scroll-tech/reth.git", default-features = false }
-reth-rpc-builder = { git = "https://github.com/scroll-tech/reth.git", default-features = false }
-reth-rpc-server-types = { git = "https://github.com/scroll-tech/reth.git", default-features = false }
-reth-tasks = { git = "https://github.com/scroll-tech/reth.git", default-features = false }
-reth-tokio-util = { git = "https://github.com/scroll-tech/reth.git", default-features = false }
-reth-tracing = { git = "https://github.com/scroll-tech/reth.git", default-features = false }
+reth-chainspec = { git = "https://github.com/scroll-tech/reth.git", branch = "feat-forward-sequencer-no-blocking", default-features = false }
+reth-e2e-test-utils = { git = "https://github.com/scroll-tech/reth.git", branch = "feat-forward-sequencer-no-blocking" }
+reth-eth-wire-types = { git = "https://github.com/scroll-tech/reth.git", branch = "feat-forward-sequencer-no-blocking", default-features = false }
+reth-network = { git = "https://github.com/scroll-tech/reth.git", branch = "feat-forward-sequencer-no-blocking", default-features = false }
+reth-network-api = { git = "https://github.com/scroll-tech/reth.git", branch = "feat-forward-sequencer-no-blocking", default-features = false }
+reth-network-peers = { git = "https://github.com/scroll-tech/reth.git", branch = "feat-forward-sequencer-no-blocking", default-features = false }
+reth-node-builder = { git = "https://github.com/scroll-tech/reth.git", branch = "feat-forward-sequencer-no-blocking", default-features = false }
+reth-node-core = { git = "https://github.com/scroll-tech/reth.git", branch = "feat-forward-sequencer-no-blocking", default-features = false }
+reth-payload-primitives = { git = "https://github.com/scroll-tech/reth.git", branch = "feat-forward-sequencer-no-blocking", default-features = false }
+reth-primitives = { git = "https://github.com/scroll-tech/reth.git", branch = "feat-forward-sequencer-no-blocking", default-features = false }
+reth-primitives-traits = { git = "https://github.com/scroll-tech/reth.git", branch = "feat-forward-sequencer-no-blocking", default-features = false }
+reth-provider = { git = "https://github.com/scroll-tech/reth.git", branch = "feat-forward-sequencer-no-blocking", default-features = false }
+reth-rpc-builder = { git = "https://github.com/scroll-tech/reth.git", branch = "feat-forward-sequencer-no-blocking", default-features = false }
+reth-rpc-server-types = { git = "https://github.com/scroll-tech/reth.git", branch = "feat-forward-sequencer-no-blocking", default-features = false }
+reth-tasks = { git = "https://github.com/scroll-tech/reth.git", branch = "feat-forward-sequencer-no-blocking", default-features = false }
+reth-tokio-util = { git = "https://github.com/scroll-tech/reth.git", branch = "feat-forward-sequencer-no-blocking", default-features = false }
+reth-tracing = { git = "https://github.com/scroll-tech/reth.git", branch = "feat-forward-sequencer-no-blocking", default-features = false }
 
 # reth-scroll
-reth-scroll-chainspec = { git = "https://github.com/scroll-tech/reth.git", default-features = false }
-reth-scroll-engine-primitives = { git = "https://github.com/scroll-tech/reth.git", default-features = false }
-reth-scroll-forks = { git = "https://github.com/scroll-tech/reth.git", default-features = false }
-reth-scroll-node = { git = "https://github.com/scroll-tech/reth.git", default-features = false }
-reth-scroll-primitives = { git = "https://github.com/scroll-tech/reth.git", default-features = false }
+reth-scroll-chainspec = { git = "https://github.com/scroll-tech/reth.git", branch = "feat-forward-sequencer-no-blocking", default-features = false }
+reth-scroll-engine-primitives = { git = "https://github.com/scroll-tech/reth.git", branch = "feat-forward-sequencer-no-blocking", default-features = false }
+reth-scroll-forks = { git = "https://github.com/scroll-tech/reth.git", branch = "feat-forward-sequencer-no-blocking", default-features = false }
+reth-scroll-node = { git = "https://github.com/scroll-tech/reth.git", branch = "feat-forward-sequencer-no-blocking", default-features = false }
+reth-scroll-primitives = { git = "https://github.com/scroll-tech/reth.git", branch = "feat-forward-sequencer-no-blocking", default-features = false }
 
 # rollup node
 rollup-node = { path = "crates/node" }

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -32,7 +32,7 @@ reth-primitives-traits.workspace = true
 # reth-scroll
 reth-scroll-chainspec.workspace = true
 reth-scroll-primitives.workspace = true
-reth-scroll-engine-primitives = { git = "https://github.com/scroll-tech/reth.git", default-features = false }
+reth-scroll-engine-primitives = { git = "https://github.com/scroll-tech/reth.git", branch = "feat-forward-sequencer-no-blocking", default-features = false }
 
 # rollup-node
 rollup-node-primitives.workspace = true
@@ -55,7 +55,7 @@ tracing.workspace = true
 alloy-consensus.workspace = true
 arbitrary.workspace = true
 async-trait.workspace = true
-reth-testing-utils = { git = "https://github.com/scroll-tech/reth.git", default-features = false }
+reth-testing-utils = { git = "https://github.com/scroll-tech/reth.git", branch = "feat-forward-sequencer-no-blocking", default-features = false }
 rollup-node-providers = { workspace = true, features = ["test-utils"] }
 scroll-alloy-consensus.workspace = true
 scroll-alloy-rpc-types-engine = { workspace = true, features = ["arbitrary"] }

--- a/crates/network/Cargo.toml
+++ b/crates/network/Cargo.toml
@@ -14,10 +14,10 @@ alloy-primitives = { workspace = true, features = ["map-foldhash"] }
 reth-eth-wire-types.workspace = true
 reth-network.workspace = true
 reth-network-api.workspace = true
-reth-network-types = { git = "https://github.com/scroll-tech/reth.git", default-features = false }
+reth-network-types = { git = "https://github.com/scroll-tech/reth.git", branch = "feat-forward-sequencer-no-blocking", default-features = false }
 reth-network-peers.workspace = true
 reth-primitives-traits.workspace = true
-reth-storage-api = { git = "https://github.com/scroll-tech/reth.git", default-features = false }
+reth-storage-api = { git = "https://github.com/scroll-tech/reth.git", branch = "feat-forward-sequencer-no-blocking", default-features = false }
 
 # scroll
 reth-scroll-chainspec.workspace = true

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -24,36 +24,36 @@ alloy-signer = "1.0.9"
 alloy-transport.workspace = true
 
 scroll-alloy-consensus.workspace = true
-scroll-alloy-evm = { git = "https://github.com/scroll-tech/reth.git" }
+scroll-alloy-evm = { git = "https://github.com/scroll-tech/reth.git", branch = "feat-forward-sequencer-no-blocking" }
 scroll-alloy-hardforks.workspace = true
 scroll-alloy-network.workspace = true
 scroll-alloy-provider.workspace = true
 
 reth-scroll-engine-primitives.workspace = true
-reth-scroll-evm = { git = "https://github.com/scroll-tech/reth.git" }
-reth-scroll-cli = { git = "https://github.com/scroll-tech/reth.git" }
+reth-scroll-evm = { git = "https://github.com/scroll-tech/reth.git", branch = "feat-forward-sequencer-no-blocking" }
+reth-scroll-cli = { git = "https://github.com/scroll-tech/reth.git", branch = "feat-forward-sequencer-no-blocking" }
 reth-scroll-primitives.workspace = true
 reth-scroll-chainspec.workspace = true
 reth-scroll-node.workspace = true
-reth-scroll-rpc = { git = "https://github.com/scroll-tech/reth.git" }
+reth-scroll-rpc = { git = "https://github.com/scroll-tech/reth.git", branch = "feat-forward-sequencer-no-blocking" }
 
 reth-chainspec.workspace = true
-reth-cli-util = { git = "https://github.com/scroll-tech/reth.git" }
+reth-cli-util = { git = "https://github.com/scroll-tech/reth.git", branch = "feat-forward-sequencer-no-blocking" }
 reth-eth-wire-types.workspace = true
-reth-evm = { git = "https://github.com/scroll-tech/reth.git" }
+reth-evm = { git = "https://github.com/scroll-tech/reth.git", branch = "feat-forward-sequencer-no-blocking" }
 reth-node-builder.workspace = true
-reth-node-api = { git = "https://github.com/scroll-tech/reth.git", default-features = false }
+reth-node-api = { git = "https://github.com/scroll-tech/reth.git", branch = "feat-forward-sequencer-no-blocking", default-features = false }
 reth-node-core.workspace = true
-reth-node-types = { git = "https://github.com/scroll-tech/reth.git", default-features = false }
+reth-node-types = { git = "https://github.com/scroll-tech/reth.git", branch = "feat-forward-sequencer-no-blocking", default-features = false }
 reth-network.workspace = true
 reth-network-api.workspace = true
-reth-revm = { git = "https://github.com/scroll-tech/reth.git", default-features = false }
-reth-rpc-api = { git = "https://github.com/scroll-tech/reth.git", default-features = false }
-reth-rpc-eth-api = { git = "https://github.com/scroll-tech/reth.git", default-features = false }
-reth-rpc-eth-types = { git = "https://github.com/scroll-tech/reth.git", default-features = false }
+reth-revm = { git = "https://github.com/scroll-tech/reth.git", branch = "feat-forward-sequencer-no-blocking", default-features = false }
+reth-rpc-api = { git = "https://github.com/scroll-tech/reth.git", branch = "feat-forward-sequencer-no-blocking", default-features = false }
+reth-rpc-eth-api = { git = "https://github.com/scroll-tech/reth.git", branch = "feat-forward-sequencer-no-blocking", default-features = false }
+reth-rpc-eth-types = { git = "https://github.com/scroll-tech/reth.git", branch = "feat-forward-sequencer-no-blocking", default-features = false }
 reth-tasks.workspace = true
-reth-transaction-pool = { git = "https://github.com/scroll-tech/reth.git", default-features = false }
-reth-trie-db = { git = "https://github.com/scroll-tech/reth.git", default-features = false }
+reth-transaction-pool = { git = "https://github.com/scroll-tech/reth.git", branch = "feat-forward-sequencer-no-blocking", default-features = false }
+reth-trie-db = { git = "https://github.com/scroll-tech/reth.git", branch = "feat-forward-sequencer-no-blocking", default-features = false }
 
 # rollup node
 rollup-node-manager.workspace = true
@@ -70,7 +70,7 @@ aws-sdk-kms = "1.76.0"
 # test-utils
 alloy-rpc-types-engine = { workspace = true, optional = true }
 reth-e2e-test-utils = { workspace = true, optional = true }
-reth-engine-local = { git = "https://github.com/scroll-tech/reth.git", default-features = false, optional = true }
+reth-engine-local = { git = "https://github.com/scroll-tech/reth.git", branch = "feat-forward-sequencer-no-blocking", default-features = false, optional = true }
 reth-provider = { workspace = true, optional = true }
 reth-rpc-server-types = { workspace = true, optional = true }
 scroll-alloy-rpc-types-engine = { workspace = true, optional = true }

--- a/crates/node/src/add_ons/mod.rs
+++ b/crates/node/src/add_ons/mod.rs
@@ -113,7 +113,8 @@ where
     type Handle = ScrollAddOnsHandle<N, <ScrollEthApiBuilder as EthApiBuilder<N>>::EthApi>;
 
     async fn launch_add_ons(self, ctx: AddOnsContext<'_, N>) -> eyre::Result<Self::Handle> {
-        let Self { rpc_add_ons, rollup_manager_addon: rollup_node_manager_addon } = self;
+        let Self { mut rpc_add_ons, rollup_manager_addon: rollup_node_manager_addon } = self;
+        rpc_add_ons.eth_api_builder.with_propagate_local_transactions(!ctx.config.txpool.no_local_transactions_propagation);
         let rpc_handle = rpc_add_ons.launch_add_ons_with(ctx.clone(), |_| Ok(())).await?;
         let (rollup_manager_handle, l1_watcher_tx) =
             rollup_node_manager_addon.launch(ctx.clone(), rpc_handle.clone()).await?;

--- a/crates/scroll-wire/Cargo.toml
+++ b/crates/scroll-wire/Cargo.toml
@@ -15,7 +15,7 @@ alloy-primitives = { workspace = true, features = ["map-foldhash"] }
 alloy-rlp = { version = "0.3.10", default-features = false }
 
 # reth
-reth-eth-wire = { git = "https://github.com/scroll-tech/reth.git", default-features = false }
+reth-eth-wire = { git = "https://github.com/scroll-tech/reth.git", branch = "feat-forward-sequencer-no-blocking", default-features = false }
 reth-network.workspace = true
 reth-network-api.workspace = true
 

--- a/crates/sequencer/Cargo.toml
+++ b/crates/sequencer/Cargo.toml
@@ -47,7 +47,7 @@ scroll-alloy-consensus.workspace = true
 # reth
 reth-e2e-test-utils.workspace = true
 reth-node-core.workspace = true
-reth-tracing = { git = "https://github.com/scroll-tech/reth.git" }
+reth-tracing = { git = "https://github.com/scroll-tech/reth.git", branch = "feat-forward-sequencer-no-blocking" }
 
 # reth-scroll
 reth-scroll-chainspec.workspace = true


### PR DESCRIPTION
This PR makes tx forwarding non-blocking if the tx propagation is enabled. If the tx propagation is disabled (private mempool mode) then the forwarding is done synchronously to notify the user. In the additional case this is not necessary as it is optional and in the failure case the transaction will simply be broadcast like usual via gossip (public mempool).

Corresponding l2geth PR: https://github.com/scroll-tech/go-ethereum/pull/1227
Corresponding Reth PR: https://github.com/scroll-tech/reth/pull/313