### PR TITLE
feat: update batch processing logic

### DIFF
--- a/crates/chain-orchestrator/src/event.rs
+++ b/crates/chain-orchestrator/src/event.rs
@@ -43,8 +43,8 @@ pub enum ChainOrchestratorEvent {
     /// A batch has been finalized returning an optional finalized L2 block. Also returns a
     /// [`BatchInfo`] if the finalized event occurred in a finalized L1 block.
     BatchFinalized(Option<WithFinalizedBlockNumber<BatchInfo>>, Option<BlockInfo>),
-    /// An L1 block has been finalized returning the L1 block number, the list of finalized batches
-    /// and an optional finalized L2 block.
+    /// An L1 block has been finalized returning the L1 block number and the list of finalized
+    /// batches.
     L1BlockFinalized(u64, Vec<BatchInfo>),
     /// A `L1Message` event has been committed returning the message queue index.
     L1MessageCommitted(u64),

--- a/crates/chain-orchestrator/src/event.rs
+++ b/crates/chain-orchestrator/src/event.rs
@@ -45,7 +45,7 @@ pub enum ChainOrchestratorEvent {
     BatchFinalized(Option<WithFinalizedBlockNumber<BatchInfo>>, Option<BlockInfo>),
     /// An L1 block has been finalized returning the L1 block number, the list of finalized batches
     /// and an optional finalized L2 block.
-    L1BlockFinalized(u64, Vec<BatchInfo>, Option<BlockInfo>),
+    L1BlockFinalized(u64, Vec<BatchInfo>),
     /// A `L1Message` event has been committed returning the message queue index.
     L1MessageCommitted(u64),
     /// A reorg has occurred on L1, returning the L1 block number of the new L1 head,

--- a/crates/database/db/src/db.rs
+++ b/crates/database/db/src/db.rs
@@ -311,7 +311,7 @@ mod test {
 
         // Fetch the finalized batch for provided height and verify number.
         let batch_infos = db
-            .get_batches_by_finalized_block_range(100, 110)
+            .fetch_and_update_unprocessed_finalized_batches(110)
             .await
             .unwrap()
             .into_iter()

--- a/crates/database/db/src/models/batch_commit.rs
+++ b/crates/database/db/src/models/batch_commit.rs
@@ -15,6 +15,7 @@ pub struct Model {
     calldata: Vec<u8>,
     blob_hash: Option<Vec<u8>>,
     pub(crate) finalized_block_number: Option<i64>,
+    processed: bool,
 }
 
 /// The relation for the batch input model.
@@ -50,6 +51,7 @@ impl From<BatchCommitData> for ActiveModel {
             calldata: ActiveValue::Set(batch_commit.calldata.0.to_vec()),
             blob_hash: ActiveValue::Set(batch_commit.blob_versioned_hash.map(|b| b.to_vec())),
             finalized_block_number: ActiveValue::Unchanged(None),
+            processed: ActiveValue::Unchanged(false),
         }
     }
 }

--- a/crates/database/migration/src/lib.rs
+++ b/crates/database/migration/src/lib.rs
@@ -8,6 +8,7 @@ mod m20250411_072004_add_l2_block;
 mod m20250616_223947_add_metadata;
 mod m20250825_093350_remove_unsafe_l2_blocks;
 mod m20250829_042803_add_table_indexes;
+mod m20250901_102341_add_commit_batch_processed_column;
 mod migration_info;
 pub use migration_info::{
     MigrationInfo, ScrollDevMigrationInfo, ScrollMainnetMigrationInfo, ScrollSepoliaMigrationInfo,
@@ -27,6 +28,7 @@ impl<MI: MigrationInfo + Send + Sync + 'static> MigratorTrait for Migrator<MI> {
             Box::new(m20250616_223947_add_metadata::Migration),
             Box::new(m20250825_093350_remove_unsafe_l2_blocks::Migration),
             Box::new(m20250829_042803_add_table_indexes::Migration),
+            Box::new(m20250901_102341_add_commit_batch_processed_column::Migration),
         ]
     }
 }

--- a/crates/database/migration/src/m20220101_000001_create_batch_commit_table.rs
+++ b/crates/database/migration/src/m20220101_000001_create_batch_commit_table.rs
@@ -64,4 +64,5 @@ pub(crate) enum BatchCommit {
     Calldata,
     BlobHash,
     FinalizedBlockNumber,
+    Processed,
 }

--- a/crates/database/migration/src/m20250901_102341_add_commit_batch_processed_column.rs
+++ b/crates/database/migration/src/m20250901_102341_add_commit_batch_processed_column.rs
@@ -1,0 +1,51 @@
+use super::m20220101_000001_create_batch_commit_table::BatchCommit;
+use sea_orm::Statement;
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        // Add the processed column to the batch_commit table.
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(BatchCommit::Table)
+                    .add_column(
+                        ColumnDef::new(BatchCommit::Processed).boolean().not_null().default(false),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+
+        // Backfill the processed column using data sourced from the l2_block table.
+        manager
+            .get_connection()
+            .execute(Statement::from_sql_and_values(
+                manager.get_database_backend(),
+                r#"
+                UPDATE batch_commit
+                SET processed = 1
+                WHERE hash IN (SELECT batch_hash FROM l2_block);
+                "#,
+                vec![],
+            ))
+            .await?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        // drop the processed column on the batch_commit table.
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(BatchCommit::Table)
+                    .drop_column(BatchCommit::Processed)
+                    .to_owned(),
+            )
+            .await
+    }
+}

--- a/crates/node/src/args.rs
+++ b/crates/node/src/args.rs
@@ -233,6 +233,7 @@ impl ScrollRollupNodeConfig {
             });
         }
 
+        tracing::info!(target: "scroll::node::args", fcs = ?fcs, payload_building_duration = ?self.sequencer_args.payload_building_duration, "Starting engine driver");
         let engine = EngineDriver::new(
             Arc::new(engine_api),
             chain_spec.clone(),
@@ -256,7 +257,7 @@ impl ScrollRollupNodeConfig {
 
         let (l1_notification_tx, l1_notification_rx): (Option<Sender<Arc<L1Notification>>>, _) =
             if let Some(provider) = l1_provider.filter(|_| !self.test) {
-                // Determine the start block number for the L1 watcher
+                tracing::info!(target: "scroll::node::args", ?l1_start_block_number, "Starting L1 watcher");
                 (None, Some(L1Watcher::spawn(provider, l1_start_block_number, node_config).await))
             } else {
                 // Create a channel for L1 notifications that we can use to inject L1 messages for

--- a/crates/node/tests/e2e.rs
+++ b/crates/node/tests/e2e.rs
@@ -977,15 +977,7 @@ async fn graceful_shutdown_consolidates_most_recent_batch_on_startup() -> eyre::
     let mut rnm_events = handle.get_event_listener().await?;
 
     // Send the second batch again to mimic the watcher behaviour.
-    l1_notification_tx.send(Arc::new(L1Notification::BatchCommit(batch_0_data.clone()))).await?;
     l1_notification_tx.send(Arc::new(L1Notification::BatchCommit(batch_1_data.clone()))).await?;
-    l1_notification_tx
-        .send(Arc::new(L1Notification::BatchFinalization {
-            hash: batch_0_data.hash,
-            index: batch_0_data.index,
-            block_number: batch_0_data.block_number,
-        }))
-        .await?;
     l1_notification_tx
         .send(Arc::new(L1Notification::BatchFinalization {
             hash: batch_1_data.hash,


### PR DESCRIPTION
# Overview
This PR modifies the way in which batches are triggered to be sent to the derivation pipeline. 

# Changes
1. Introduction of a `processed` column on the `batch_commit` table and associated migrations.
2. Modify startup logic to set the `start_l1_block_number` using the correct `block_number` from the last fully processed batch.
3. Modify logic for selecting and pushing batches into the derivation pipeline.