### PR TITLE
feat: add sqlite3 to docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN --mount=target=. \
 
 FROM debian:bookworm-slim
 
-RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl && \
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl sqlite3 && \
     rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app


### PR DESCRIPTION
# Overview
This PR adds sqlite3 to the Docker image. This will allow us to interrogate and debug the database using the terminal. 