### PR TITLE
feat: defensive indexing

### DIFF
--- a/crates/chain-orchestrator/src/error.rs
+++ b/crates/chain-orchestrator/src/error.rs
@@ -29,6 +29,10 @@ pub enum ChainOrchestratorError {
     /// An L1 message was not found in the database.
     #[error("L1 message not found at {0}")]
     L1MessageNotFound(L1MessageStart),
+    /// A gap was detected in the L1 message queue: the previous message before index {0} is
+    /// missing.
+    #[error("L1 message queue gap detected at index {0}, previous L1 message not found")]
+    L1MessageQueueGap(u64),
     /// An inconsistency was detected when trying to consolidate the chain.
     #[error("Chain inconsistency detected")]
     ChainInconsistency,
@@ -38,6 +42,9 @@ pub enum ChainOrchestratorError {
         /// The hash of the block header that was requested.
         hash: B256,
     },
+    /// A gap was detected in batch commit events: the previous batch before index {0} is missing.
+    #[error("Batch commit gap detected at index {0}, previous batch commit not found")]
+    BatchCommitGap(u64),
     /// An error occurred while making a network request.
     #[error("Network request error: {0}")]
     NetworkRequestError(#[from] reth_network_p2p::error::RequestError),

--- a/crates/chain-orchestrator/src/lib.rs
+++ b/crates/chain-orchestrator/src/lib.rs
@@ -661,6 +661,7 @@ impl<
         let txn = database.tx().await?;
         let prev_batch_index = batch.index - 1;
 
+        // Perform a consistency check to ensure the previous commit batch exists in the database.
         if txn.get_batch_by_index(prev_batch_index).await?.is_none() {
             return Err(ChainOrchestratorError::BatchCommitGap(batch.index))
         }

--- a/crates/manager/src/manager/mod.rs
+++ b/crates/manager/src/manager/mod.rs
@@ -349,9 +349,11 @@ where
     fn handle_chain_orchestrator_error(&self, err: &ChainOrchestratorError) {
         error!(
             target: "scroll::node::manager",
-            ?err,
+            error = ?err,
+            msg = %err,
             "Error occurred in the chain orchestrator"
         );
+
         match err {
             ChainOrchestratorError::L1MessageMismatch { expected, actual } => {
                 if let Some(event_sender) = self.event_sender.as_ref() {


### PR DESCRIPTION
# Overview
This PR introduces two never `ChaiOrchestratorError` variants:
- `L1MessageQueueGap`
- `BatchCommitGap`

These are thrown when gaps are detected during indexing. We also update the error logging pattern to log both debug (`?`) and display (`%`) representations of the errors:
```rust
        error!(
            target: "scroll::node::manager",
            ?err,
            error = ?err,
            msg = %err,
            "Error occurred in the chain orchestrator"
        );
```