### PR TITLE
feat: update batch finalization logic

### DIFF
--- a/crates/chain-orchestrator/src/event.rs
+++ b/crates/chain-orchestrator/src/event.rs
@@ -2,9 +2,7 @@ use alloy_consensus::Header;
 use alloy_primitives::{Signature, B256};
 use reth_network_peers::PeerId;
 use reth_scroll_primitives::ScrollBlock;
-use rollup_node_primitives::{
-    BatchInfo, BlockInfo, ChainImport, L2BlockInfoWithL1Messages, WithFinalizedBlockNumber,
-};
+use rollup_node_primitives::{BatchInfo, BlockInfo, ChainImport, L2BlockInfoWithL1Messages};
 
 /// An event emitted by the `ChainOrchestrator`.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -40,9 +38,8 @@ pub enum ChainOrchestratorEvent {
         /// The safe L2 block info.
         safe_head: Option<BlockInfo>,
     },
-    /// A batch has been finalized returning an optional finalized L2 block. Also returns a
-    /// [`BatchInfo`] if the finalized event occurred in a finalized L1 block.
-    BatchFinalized(Option<WithFinalizedBlockNumber<BatchInfo>>, Option<BlockInfo>),
+    /// A batch has been finalized returning a list of finalized batches.
+    BatchFinalized(u64, Vec<BatchInfo>),
     /// An L1 block has been finalized returning the L1 block number and the list of finalized
     /// batches.
     L1BlockFinalized(u64, Vec<BatchInfo>),

--- a/crates/manager/src/manager/mod.rs
+++ b/crates/manager/src/manager/mod.rs
@@ -274,7 +274,7 @@ where
                 // // push the batch info into the derivation pipeline.
                 // self.derivation_pipeline.push_batch(batch_info, l1_block_number);
             }
-            ChainOrchestratorEvent::BatchFinalized(batch_info, ..) => {
+            ChainOrchestratorEvent::BatchFinalized(block_number, finalized_batches) => {
                 // Uncomment once we implement issue #273.
                 // // update the fcs on new finalized block.
                 // if let Some(finalized_block) = finalized_block {
@@ -282,9 +282,8 @@ where
                 // }
                 // Remove once we implement issue #273.
                 // Update the derivation pipeline on new finalized batch.
-                #[allow(clippy::collapsible_match)]
-                if let Some(batch_info) = batch_info {
-                    self.derivation_pipeline.push_batch(batch_info.inner, batch_info.number);
+                for batch_info in finalized_batches {
+                    self.derivation_pipeline.push_batch(batch_info, block_number);
                 }
             }
             ChainOrchestratorEvent::L1BlockFinalized(l1_block_number, finalized_batches, ..) => {


### PR DESCRIPTION
# Overview
Previously, we would wait for an L1 block finalization event before triggering batches to be processed by the derivation pipeline. This resulted in an issue with historical sync as it accumulates a large number of batch commits in the database and then emits them all at once, resulting in a large memory footprint. This PR modifies the logic to emit batches to the derivation pipeline upon a batch finalization event if the batch finalizaton event is already finalized.