### PR TITLE
feat: max l1 messages per block

### DIFF
--- a/crates/node/src/args.rs
+++ b/crates/node/src/args.rs
@@ -342,7 +342,9 @@ impl ScrollRollupNodeConfig {
                 Arc::new(l1_messages_provider),
                 args.fee_recipient,
                 ctx.block_gas_limit,
-                chain_config.l1_config.num_l1_messages_per_block,
+                self.sequencer_args
+                    .max_l1_messages
+                    .unwrap_or(chain_config.l1_config.num_l1_messages_per_block),
                 0,
                 self.sequencer_args.l1_message_inclusion_mode,
             );
@@ -638,6 +640,13 @@ pub struct SequencerArgs {
         default_value_t = false
     )]
     pub allow_empty_blocks: bool,
+    /// The maximum number of L1 messages to include per L2 block.
+    #[arg(
+        long = "sequencer.max-l1-messages",
+        id = "sequencer_max_l1_messages",
+        value_name = "SEQUENCER_MAX_L1_MESSAGES"
+    )]
+    pub max_l1_messages: Option<u64>,
 }
 
 /// The arguments for the signer.

--- a/crates/node/src/args.rs
+++ b/crates/node/src/args.rs
@@ -644,7 +644,8 @@ pub struct SequencerArgs {
     #[arg(
         long = "sequencer.max-l1-messages",
         id = "sequencer_max_l1_messages",
-        value_name = "SEQUENCER_MAX_L1_MESSAGES"
+        value_name = "SEQUENCER_MAX_L1_MESSAGES",
+        help = "The maximum number of L1 messages to include per L2 block. If not set, defaults to the value specified in the chain config."
     )]
     pub max_l1_messages: Option<u64>,
 }

--- a/crates/node/src/test_utils.rs
+++ b/crates/node/src/test_utils.rs
@@ -189,6 +189,7 @@ pub fn default_sequencer_test_scroll_rollup_node_config() -> ScrollRollupNodeCon
             fee_recipient: Default::default(),
             l1_message_inclusion_mode: L1MessageInclusionMode::BlockDepth(0),
             allow_empty_blocks: true,
+            max_l1_messages: None,
         },
         blob_provider_args: BlobProviderArgs { mock: true, ..Default::default() },
         signer_args: Default::default(),


### PR DESCRIPTION
# Overview
Adds a CLI argument that allows the user to override the maximum number of L1 messages per L2 block.