### PR TITLE
feat: set engine persistence threshold to 0

### DIFF
--- a/crates/node/src/main.rs
+++ b/crates/node/src/main.rs
@@ -35,7 +35,7 @@ fn main() {
                         .config()
                         .engine
                         .tree_config()
-                        .with_always_process_payload_attributes_on_canonical_head(true);
+                        .with_always_process_payload_attributes_on_canonical_head(true).with_persistence_threshold(0);
                     let launcher = EngineNodeLauncher::new(
                         builder.task_executor().clone(),
                         builder.config().datadir(),

--- a/crates/node/src/test_utils.rs
+++ b/crates/node/src/test_utils.rs
@@ -90,7 +90,8 @@ where
             .with_add_ons(node.add_ons())
             .launch_with_fn(|builder| {
                 let tree_config = TreeConfig::default()
-                    .with_always_process_payload_attributes_on_canonical_head(true);
+                    .with_always_process_payload_attributes_on_canonical_head(true)
+                    .with_persistence_threshold(0);
                 let launcher = EngineNodeLauncher::new(
                     builder.task_executor().clone(),
                     builder.config().datadir(),


### PR DESCRIPTION
# Overview
This PR sets the engine persistence threshold to 0, such that we immediately persist canonical blocks on the EN as soon as they are flagged as part of the canonical chain.