### PR TITLE
add handling of error status in beacon blob provider

### DIFF
--- a/crates/providers/src/l1/blob/client.rs
+++ b/crates/providers/src/l1/blob/client.rs
@@ -111,14 +111,10 @@ impl BeaconClientProvider {
 
     /// Returns the blobs for the provided slot.
     async fn blobs(&self, slot: u64) -> Result<Vec<BlobData>, reqwest::Error> {
-        let raw_response = self
-            .inner
-            .get(format!("{}/{}/{}", self.base, Self::SIDECARS_METHOD_PREFIX, slot))
-            .send()
-            .await?;
-        let raw_response = raw_response.json::<BeaconBlobBundle>().await?;
-
-        Ok(raw_response.data)
+        let url = format!("{}/{}/{}", self.base, Self::SIDECARS_METHOD_PREFIX, slot);
+        let response = self.inner.get(&url).send().await?.error_for_status()?;
+        let blob_bundle = response.json::<BeaconBlobBundle>().await?;
+        Ok(blob_bundle.data)
     }
 
     /// Returns the beacon slot given a block timestamp.


### PR DESCRIPTION
# Overview
This PR leverages `error_for_status` to error on a http status that is not a success. This prevents us from attempting to decode the data payload for errror responses.