### PR TITLE
feat: add analyze data to migration

### DIFF
--- a/crates/database/db/src/operations.rs
+++ b/crates/database/db/src/operations.rs
@@ -900,8 +900,8 @@ impl<T: ReadConnectionProvider + Sync + ?Sized> DatabaseReadOperations for T {
                 // (i.e. L2BlockNumber is null) nor skipped.
                 let condition = Condition::all()
                     .add(models::l1_message::Column::L1BlockNumber.lte(target_block_number as i64))
-                    .add(models::l1_message::Column::Skipped.eq(false))
-                    .add(models::l1_message::Column::L2BlockNumber.is_null());
+                    .add(models::l1_message::Column::L2BlockNumber.is_null())
+                    .add(models::l1_message::Column::Skipped.eq(false));
                 // Yield n messages matching the condition ordered by increasing queue index.
                 Ok(models::l1_message::Entity::find()
                     .filter(condition)

--- a/crates/database/migration/src/lib.rs
+++ b/crates/database/migration/src/lib.rs
@@ -17,6 +17,7 @@ mod m20251005_160938_add_initial_l1_block_numbers;
 mod m20251013_140946_add_initial_l1_processed_block_number;
 mod m20251021_070729_add_skipped_column;
 mod m20251021_144852_add_queue_index_index;
+mod m20251027_090416_add_table_statistics;
 
 mod migration_info;
 pub use migration_info::{
@@ -46,6 +47,7 @@ impl<MI: MigrationInfo + Send + Sync + 'static> MigratorTrait for Migrator<MI> {
             Box::new(m20251013_140946_add_initial_l1_processed_block_number::Migration),
             Box::new(m20251021_070729_add_skipped_column::Migration),
             Box::new(m20251021_144852_add_queue_index_index::Migration),
+            Box::new(m20251027_090416_add_table_statistics::Migration),
         ]
     }
 }

--- a/crates/database/migration/src/m20251027_090416_add_table_statistics.rs
+++ b/crates/database/migration/src/m20251027_090416_add_table_statistics.rs
@@ -1,0 +1,45 @@
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        let db = manager.get_connection();
+
+        db.execute_unprepared("ANALYZE;").await?;
+        db.execute_unprepared("DELETE FROM sqlite_stat1;").await?;
+        db.execute_unprepared(
+            r#"
+                INSERT INTO sqlite_stat1(tbl, idx, stat) VALUES
+                    ('block_signature', 'idx_block_signature_block_hash', '96134 1'),
+                    ('block_signature', 'sqlite_autoindex_block_signature_1', '96134 1'),
+                    ('metadata', 'sqlite_autoindex_metadata_1', '4 1'),
+                    ('l2_block', 'idx_batch_index', '14240240 120'),
+                    ('l2_block', 'idx_batch_hash', '14240240 120'),
+                    ('l2_block', 'idx_block_hash', '14240240 1'),
+                    ('l2_block', 'idx_l2_block_block_number', '14240240 1'),
+                    ('block_data', 'sqlite_autoindex_block_data_1', '8484488 1'),
+                    ('l1_message', 'idx_l1_message_queue_index', '1079892 1'),
+                    ('l1_message', 'idx_l1_message_l2_block', '1079892 8'),
+                    ('l1_message', 'idx_l1_block_number', '1079892 3'),
+                    ('l1_message', 'idx_l1_message_hash', '1079892 1'),
+                    ('l1_message', 'idx_queue_hash', '1079892 61'),
+                    ('batch_commit', 'idx_finalized_block_number', '118854 2'),
+                    ('batch_commit', 'idx_batch_commit_block_number', '118854 2'),
+                    ('batch_commit', 'idx_batch_commit_hash', '118854 1'),
+                    ('batch_commit', 'sqlite_autoindex_batch_commit_1', '118854 1'),
+                    ('seaql_migrations', 'sqlite_autoindex_seaql_migrations_1', '17 1');
+            "#,
+        )
+        .await?;
+        db.execute_unprepared("ANALYZE sqlite_schema;").await?;
+
+        Ok(())
+    }
+
+    async fn down(&self, _manager: &SchemaManager) -> Result<(), DbErr> {
+        Ok(())
+    }
+}


### PR DESCRIPTION
Embed the analyze data from the sqlite in the migrations. Don't include the processed and skipped indexes since the data is skewed related to these indexes.

closes: #386 