### PR TITLE
feat(derivation-pipeline): Accept CodecV9 (Galileo)

### DIFF
--- a/crates/codec/src/decoding/v7/mod.rs
+++ b/crates/codec/src/decoding/v7/mod.rs
@@ -31,7 +31,7 @@ pub fn decode_v7(blob: &[u8]) -> Result<Batch, DecodingError> {
 
     // check version.
     let version = from_be_bytes_slice_and_advance_buf!(u8, buf);
-    debug_assert!((version == 7) | (version == 8), "incorrect blob version");
+    debug_assert!((version == 7) || (version == 8) || (version == 9), "incorrect blob version");
 
     let blob_payload_size = from_be_bytes_slice_and_advance_buf!(u32, 3, buf) as usize;
 

--- a/crates/codec/src/error.rs
+++ b/crates/codec/src/error.rs
@@ -12,8 +12,6 @@ pub enum CodecError {
 /// An error occurring during the decoding.
 #[derive(Debug, thiserror::Error)]
 pub enum DecodingError {
-    #[error("missing codec version in input")]
-    MissingCodecVersion,
     #[error("unsupported codec version {0}")]
     UnsupportedCodecVersion(u8),
     #[error("malformed codec version: {0}")]

--- a/crates/codec/src/lib.rs
+++ b/crates/codec/src/lib.rs
@@ -59,7 +59,7 @@ impl Codec {
                 let blob = input.blob().ok_or(DecodingError::MissingBlob)?;
                 decode_v4(calldata, blob.as_ref())?
             }
-            7..=8 => {
+            7..=9 => {
                 let blob = input.blob().ok_or(DecodingError::MissingBlob)?;
                 decode_v7(blob.as_ref())?
             }


### PR DESCRIPTION
Accept da-codec version 9. This version is identical to v7 and v8, except for the version byte in the batch header and the blob payload. See also https://github.com/scroll-tech/da-codec/pull/66.