### PR TITLE
fix: l1 watcher log length check

### DIFF
--- a/crates/watcher/src/lib.rs
+++ b/crates/watcher/src/lib.rs
@@ -342,7 +342,8 @@ where
             }
 
             // Check that we haven't generated more notifications than logs
-            // Note: notifications.len() may be less than logs.len() because genesis batch (batch_index=0) is intentionally skipped
+            // Note: notifications.len() may be less than logs.len() because genesis batch
+            // (batch_index=0) is intentionally skipped
             if notifications.len() > logs.len() {
                 return Err(L1WatcherError::Logs(FilterLogError::InvalidNotificationCount(
                     logs.len(),


### PR DESCRIPTION
This PR fix the issue of l1 watcher, which we check if [`notifications.len() == logs.len`](https://github.com/scroll-tech/rollup-node/blob/655baa77f107edbee508b4bfb3e16c0a8e4c88d4/crates/watcher/src/lib.rs#L344-L349). But this check won't pass if logs contains commit/finalized genesis event batch. So we change the condition to `notifications.len() > logs.len()` which we still can catch most bugs.

corresponding issue: https://github.com/scroll-tech/rollup-node/issues/424