### PR TITLE
feat: always update safe head

### DIFF
--- a/crates/chain-orchestrator/src/consolidation.rs
+++ b/crates/chain-orchestrator/src/consolidation.rs
@@ -36,12 +36,13 @@ pub(crate) async fn reconcile_batch<L2P: Provider<Scroll>>(
                 // Extract the block info with L1 messages.
                 let block_info: L2BlockInfoWithL1Messages = (&current_block).into();
 
-                // The block matches the derived attributes and the block is below or equal to the
-                // safe current safe head.
+                // The derived attributes match the L2 chain but are associated with a block
+                // number less than or equal to the finalized block, so skip.
                 if attributes.block_number <= fcs.finalized_block_info().number {
                     Ok::<_, ChainOrchestratorError>(BlockConsolidationAction::Skip(block_info))
                 } else {
-                    // The block matches the derived attributes, no action is needed.
+                    // The block matches the derived attributes but is above the finalized block,
+                    // so we need to update the fcs.
                     Ok::<_, ChainOrchestratorError>(BlockConsolidationAction::UpdateFcs(block_info))
                 }
             } else {


### PR DESCRIPTION
# Overview
This PR changes the consolidation logic such that we always update the fork choice state if the block number is greater than the finalized block number. This allows us to account for the case in which a reorg has occurred and the new batch is different from the old. In the model on the `main` branch, we would be eventually consistent when `attributes.number > fcs.safe_blcock_info().number` but the model in this PR reduces latency to arrive at the correct state.