### PR TITLE
Revert "feat: always update safe head (#434)"

### DIFF
--- a/crates/chain-orchestrator/src/consolidation.rs
+++ b/crates/chain-orchestrator/src/consolidation.rs
@@ -36,13 +36,15 @@ pub(crate) async fn reconcile_batch<L2P: Provider<Scroll>>(
                 // Extract the block info with L1 messages.
                 let block_info: L2BlockInfoWithL1Messages = (&current_block).into();
 
-                // The derived attributes match the L2 chain but are associated with a block
-                // number less than or equal to the finalized block, so skip.
-                if attributes.block_number <= fcs.finalized_block_info().number {
+                // The block matches the derived attributes and the block is below or equal to the
+                // safe current safe head.
+                if attributes.block_number <= fcs.finalized_block_info().number ||
+                    ((attributes.block_number <= fcs.safe_block_info().number) &&
+                        batch.target_status.is_consolidated())
+                {
                     Ok::<_, ChainOrchestratorError>(BlockConsolidationAction::Skip(block_info))
                 } else {
-                    // The block matches the derived attributes but is above the finalized block,
-                    // so we need to update the fcs.
+                    // The block matches the derived attributes, no action is needed.
                     Ok::<_, ChainOrchestratorError>(BlockConsolidationAction::UpdateFcs(block_info))
                 }
             } else {


### PR DESCRIPTION
This logic may introduce bugs as I don't think the EN allows for the safe head to go backwards, hence I am reverting to the previously tested logic.

This reverts commit 81c904c71040437ea3c0a2048d6d1a8f4800ed55.